### PR TITLE
feat(seeding): add configuration values

### DIFF
--- a/charts/centralidp/templates/job-seeding.yaml
+++ b/charts/centralidp/templates/job-seeding.yaml
@@ -60,9 +60,9 @@ spec:
           - name: "KEYCLOAKSEEDING__INSTANCENAME"
             value: "{{ .Values.seeding.instanceName }}"
           - name: "KEYCLOAKSEEDING__EXCLUDEDUSERATTRIBUTES__0"
-            value: "{{ .Values.seeding.excludedUserAttributes.bpn }}"
+            value: "{{ .Values.seeding.excludedUserAttributes.attribute0 }}"
           - name: "KEYCLOAKSEEDING__EXCLUDEDUSERATTRIBUTES__1"
-            value: "{{ .Values.seeding.excludedUserAttributes.organisation }}"
+            value: "{{ .Values.seeding.excludedUserAttributes.attribute1 }}"
         ports:
         - name: http
           containerPort: {{ .Values.seeding.portContainer }}

--- a/charts/centralidp/templates/job-seeding.yaml
+++ b/charts/centralidp/templates/job-seeding.yaml
@@ -59,6 +59,10 @@ spec:
             value: "{{ .Values.seeding.dataPaths.dataPath0 }}"
           - name: "KEYCLOAKSEEDING__INSTANCENAME"
             value: "{{ .Values.seeding.instanceName }}"
+          - name: "KEYCLOAKSEEDING__EXCLUDEDUSERATTRIBUTES__0"
+            value: "{{ .Values.seeding.excludedUserAttributes.bpn }}"
+          - name: "KEYCLOAKSEEDING__EXCLUDEDUSERATTRIBUTES__1"
+            value: "{{ .Values.seeding.excludedUserAttributes.organisation }}"
         ports:
         - name: http
           containerPort: {{ .Values.seeding.portContainer }}

--- a/charts/centralidp/values.yaml
+++ b/charts/centralidp/values.yaml
@@ -156,6 +156,9 @@ seeding:
   dataPaths:
     dataPath0: "realms/CX-Central-realm.json"
   instanceName: "central"
+  excludedUserAttributes:
+    bpn: "bpn"
+    organisation: "organisation"
   # -- We recommend not to specify default resources and to leave this as a conscious choice for the user.
   # If you do want to specify resources, uncomment the following lines,
   # adjust them as necessary, and remove the curly braces after 'resources:'.

--- a/charts/centralidp/values.yaml
+++ b/charts/centralidp/values.yaml
@@ -157,8 +157,8 @@ seeding:
     dataPath0: "realms/CX-Central-realm.json"
   instanceName: "central"
   excludedUserAttributes:
-    bpn: "bpn"
-    organisation: "organisation"
+    attribute0: "bpn"
+    attribute1: "organisation"
   # -- We recommend not to specify default resources and to leave this as a conscious choice for the user.
   # If you do want to specify resources, uncomment the following lines,
   # adjust them as necessary, and remove the curly braces after 'resources:'.


### PR DESCRIPTION
## Description

Add configuration to exclude bpn and organisation from user attributes while seeding

## Why

To not overwrite already existing values

## Issue

N/A - Jira Issue: CPLP-3530

## Corresponding Backend PR

[#346](https://github.com/eclipse-tractusx/portal-backend/pull/346)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
