### PR TITLE
chore(kics): exclude docs directory from scan

### DIFF
--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -65,6 +65,7 @@ jobs:
           # GITHUB_TOKEN enables this github action to access github API and post comments in a pull request
           # token: ${{ secrets.GITHUB_TOKEN }}
           # enable_comments: true
+          exclude_paths: ./docs/*
 
       # Upload findings to GitHub Advanced Security Dashboard
       - name: Upload SARIF file for GitHub Advanced Security Dashboard


### PR DESCRIPTION
## Description

exclude docs directory from kics scan

## Why

example in docs folder leads to false positive, example run:
https://github.com/eclipse-tractusx/portal-iam/actions/runs/6958476672
![image](https://github.com/eclipse-tractusx/portal-iam/assets/46191613/a94ba58f-7abd-434f-ae01-7dad5cb36784)


## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
