### PR TITLE
fix(init-realm): change role assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,11 @@ New features, fixed bugs, known defects and other noteworthy changes to each rel
   * created role "view_managed_idp" inside the Cl2-CX-Portal client and assigned it to the composite roles "IT Admin" and "Company Admin"
   * assigned role "view_semantic_models" from the Cl3-CX-Semantic client to the composite role "Semantic Model Management" from the technical_roles_management client
   * assigned role "view_membership" from the Cl2-CX-Portal client to the composite role "CX Membership Info" from the technical_roles_management client
-  * assigned roles "view_bpn_discovery", "add_bpn_discovery" and "delete_bpn_discovery" from of the Cl22-CX-BPND client, the role "view_discovery_endpoint" from of the Cl21-CX-DF client and role "view_wallet" from of the Cl5-CX-Custodian client to the composite role "Dataspace Discovery" from the technical_roles_management client
+  * assigned roles "view_bpn_discovery", "add_bpn_discovery" and "delete_bpn_discovery" from of the Cl22-CX-BPND client, the role "view_discovery_endpoint" from of the Cl21-CX-DF client to the composite role "Dataspace Discovery" from the technical_roles_management client
   * created roles "configure_partner_registration" and "create_partner_registration" inside the Cl2-CX-Portal client
   * assigned role "create_partner_registration" to the composite role "Registration External" from the technical_roles_management client
   * assigned role "configure_partner_registration" to the composite roles "Company Admin" and "IT Admin"
+  * assigned composite roles Semantic Model Management", "Dataspace Discovery" and "Identity Wallet Management" from the technical_roles_management client to service account sa-cl3-cx-1
   * created composite role "Offer Management" in client technical_roles_management and associated client roles "add_service_offering", "add_connectors" and "activate_subscription" from Cl2-CX-Portal
   * created the client "Cl16-CX-BPDMGate" with the client roles "view_company_data", "update_company_data" and "view_shared_data" and assigned those to service account sa-cl7-cx-5
   * deleted the composite roles "App Tech User", "Connector User" and "Service Management" from client technical_roles_management

--- a/charts/centralidp/values.yaml
+++ b/charts/centralidp/values.yaml
@@ -48,7 +48,7 @@ keycloak:
       mountPath: "/realms"
   initContainers:
     - name: import
-      image: tractusx/portal-iam:pr29
+      image: tractusx/portal-iam:pr38
       imagePullPolicy: Always
       command:
         - sh
@@ -178,7 +178,7 @@ seeding:
       mountPath: "app/realms"
   initContainers:
     - name: init-cx-central
-      image: tractusx/portal-iam:pr29
+      image: tractusx/portal-iam:pr38
       imagePullPolicy: Always
       command:
         - sh

--- a/charts/sharedidp/values.yaml
+++ b/charts/sharedidp/values.yaml
@@ -52,7 +52,7 @@ keycloak:
       mountPath: "/realms"
   initContainers:
     - name: import
-      image: tractusx/portal-iam:pr29
+      image: tractusx/portal-iam:pr38
       imagePullPolicy: Always
       command:
         - sh

--- a/consortia/argocd-app-templates/centralidp/appsetup-templateconsortia.yaml
+++ b/consortia/argocd-app-templates/centralidp/appsetup-templateconsortia.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/centralidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: upgrade/update-init-realm-json-files
+    targetRevision: main
     plugin:
       env:
         - name: AVP_SECRET

--- a/consortia/argocd-app-templates/centralidp/appsetup-templategeneric.yaml
+++ b/consortia/argocd-app-templates/centralidp/appsetup-templategeneric.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/centralidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: upgrade/update-init-realm-json-files
+    targetRevision: main
     plugin:
       env:
         - name: AVP_SECRET

--- a/consortia/argocd-app-templates/sharedidp/appsetup-templateconsortia.yaml
+++ b/consortia/argocd-app-templates/sharedidp/appsetup-templateconsortia.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/sharedidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: upgrade/update-init-realm-json-files
+    targetRevision: main
     plugin:
       env:
         - name: AVP_SECRET

--- a/consortia/argocd-app-templates/sharedidp/appsetup-templategeneric.yaml
+++ b/consortia/argocd-app-templates/sharedidp/appsetup-templategeneric.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/sharedidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: upgrade/update-init-realm-json-files
+    targetRevision: main
     plugin:
       env:
         - name: AVP_SECRET

--- a/consortia/environments/centralidp/values-templateconsortia.yaml
+++ b/consortia/environments/centralidp/values-templateconsortia.yaml
@@ -22,7 +22,7 @@ keycloak:
   proxy: edge
   initContainers:
     - name: import
-      image: tractusx/portal-iam-consortia:pr29
+      image: tractusx/portal-iam-consortia:pr38
       imagePullPolicy: Always
       command:
         - sh
@@ -70,7 +70,7 @@ seeding:
   image: "tractusx/portal-iam-seeding:dev"
   initContainers:
     - name: init-cx-central
-      image: tractusx/portal-iam-consortia:pr29
+      image: tractusx/portal-iam-consortia:pr38
       imagePullPolicy: Always
       command:
         - sh

--- a/consortia/environments/centralidp/values-templategeneric.yaml
+++ b/consortia/environments/centralidp/values-templategeneric.yaml
@@ -22,7 +22,7 @@ keycloak:
   proxy: edge
   initContainers:
     - name: import
-      image: tractusx/portal-iam:pr29
+      image: tractusx/portal-iam:pr38
       imagePullPolicy: Always
       command:
         - sh
@@ -70,7 +70,7 @@ seeding:
   image: "tractusx/portal-iam-seeding:rc"
   initContainers:
     - name: init-cx-central
-      image: tractusx/portal-iam:pr29
+      image: tractusx/portal-iam:pr38
       imagePullPolicy: Always
       command:
         - sh

--- a/consortia/environments/sharedidp/values-templateconsortia.yaml
+++ b/consortia/environments/sharedidp/values-templateconsortia.yaml
@@ -41,7 +41,7 @@ keycloak:
       mountPath: "/secrets"
   initContainers:
     - name: import
-      image: tractusx/portal-iam-consortia:pr29
+      image: tractusx/portal-iam-consortia:pr38
       imagePullPolicy: Always
       command:
         - sh

--- a/consortia/environments/sharedidp/values-templategeneric.yaml
+++ b/consortia/environments/sharedidp/values-templategeneric.yaml
@@ -36,7 +36,7 @@ keycloak:
       mountPath: "/realms"
   initContainers:
     - name: import
-      image: tractusx/portal-iam:pr29
+      image: tractusx/portal-iam:pr38
       imagePullPolicy: Always
       command:
         - sh

--- a/import/realm-config/consortia/catenax-central/beta/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/beta/CX-Central-realm.json
@@ -1176,9 +1176,9 @@
                 "delete_tech_user_management",
                 "delete_own_user_account",
                 "my_user_account",
-                "unsubscribe_services",
                 "create_notifications",
                 "edit_apps",
+                "unsubscribe_services",
                 "view_apps",
                 "modify_connectors",
                 "view_use_case_participation",
@@ -1943,9 +1943,6 @@
               "Cl21-CX-DF": [
                 "view_discovery_endpoint"
               ],
-              "Cl5-CX-Custodian": [
-                "view_wallet"
-              ],
               "Cl2-CX-Portal": [
                 "view_connectors"
               ]
@@ -2548,9 +2545,9 @@
   "otpPolicyPeriod": 30,
   "otpPolicyCodeReusable": false,
   "otpSupportedApplications": [
-    "totpAppGoogleName",
     "totpAppMicrosoftAuthenticatorName",
-    "totpAppFreeOTPName"
+    "totpAppFreeOTPName",
+    "totpAppGoogleName"
   ],
   "webAuthnPolicyRpEntityName": "keycloak",
   "webAuthnPolicySignatureAlgorithms": [
@@ -3221,6 +3218,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3248,6 +3246,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3275,6 +3274,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3302,6 +3302,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3329,6 +3330,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3356,6 +3358,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3383,6 +3386,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3615,6 +3619,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -3647,6 +3652,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3813,6 +3819,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl5-CX-Custodian": [
@@ -3843,6 +3850,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3932,6 +3940,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -3964,6 +3973,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -3997,6 +4007,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4055,6 +4066,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4113,6 +4125,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4164,6 +4177,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4191,6 +4205,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4222,6 +4237,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4370,6 +4386,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4453,6 +4470,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4503,6 +4521,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4525,6 +4544,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4552,6 +4572,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4579,6 +4600,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4609,6 +4631,7 @@
         ],
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4995,7 +5018,8 @@
         "client": "sa-cl3-cx-1",
         "roles": [
           "Dataspace Discovery",
-          "Semantic Model Management"
+          "Semantic Model Management",
+          "Identity Wallet Management"
         ]
       }
     ],
@@ -7486,8 +7510,8 @@
         "backchannel.logout.session.required": "true",
         "client_credentials.use_refresh_token": "false",
         "saml_force_name_id_format": "false",
-        "require.pushed.authorization.requests": "false",
         "saml.client.signature": "false",
+        "require.pushed.authorization.requests": "false",
         "tls.client.certificate.bound.access.tokens": "false",
         "saml.authnstatement": "false",
         "display.on.consent.screen": "false",
@@ -15181,6 +15205,21 @@
           }
         },
         {
+          "id": "4baa14b7-833e-4bcb-a052-090e65c2bc2c",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
           "id": "1d94ee73-6981-486c-a2d8-2e2f857cd125",
           "name": "bpn-mapper",
           "protocol": "openid-connect",
@@ -15331,7 +15370,6 @@
           "protocolMapper": "oidc-address-mapper",
           "consentRequired": false,
           "config": {
-            "user.attribute.formatted": "formatted",
             "user.attribute.country": "country",
             "user.attribute.postal_code": "postal_code",
             "userinfo.token.claim": "true",
@@ -16049,139 +16087,7 @@
   ],
   "identityProviderMappers": [
     {
-      "id": "6f8779b1-dda1-4803-ac46-d5c921a68219",
-      "name": "username-mapper",
-      "identityProviderAlias": "App-Provider",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "8fb729cf-2836-417b-95c5-e83f2dcf9425",
-      "name": "username-mapper",
-      "identityProviderAlias": "Service-Provider",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "64417652-af15-4e95-bebd-5cf2cec7ce0c",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "App-Provider",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "App-Provider",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "ddd0398c-c38a-48b4-b1b3-9eaa6599ac5d",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "CX-Test-Access",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "CX-Test-Access",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "6b19e978-7602-46e3-84fd-9faaa4d28c19",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "CX-Operator",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "CX-Operator",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "69d4a3f9-3e58-4efc-97f3-b4b4d633dcea",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "Company-2",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "company-2",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "f2bf3c88-2da6-4162-b354-349820707d09",
-      "name": "username-mapper",
-      "identityProviderAlias": "Company-1",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "d2d5c005-0059-4853-b64b-dad4c4bdbacb",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "Company-1",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "company-1",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "7b380535-fdb6-4766-a5e6-4405260831ba",
-      "name": "username-mapper",
-      "identityProviderAlias": "Company-2",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "cdbba93b-808f-4101-bd02-f51139ebb107",
-      "name": "username-mapper",
-      "identityProviderAlias": "CX-Operator",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "84c1924d-2208-4a55-b96a-9dfbadd9ce29",
-      "name": "username mapper",
-      "identityProviderAlias": "CX-Test-Access",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "b40269c4-a53b-42d1-8949-c20088824b68",
-      "name": "username mapper",
-      "identityProviderAlias": "Security-Company",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "9933e158-0d5b-4eea-8836-08b54be84330",
+      "id": "7698c5c5-61de-47d4-a0f7-45956bc3448b",
       "name": "organisation-mapper",
       "identityProviderAlias": "Service-Provider",
       "identityProviderMapper": "hardcoded-attribute-idp-mapper",
@@ -16192,7 +16098,7 @@
       }
     },
     {
-      "id": "3320adcc-acc2-4129-9a3c-ed10a71bee5e",
+      "id": "362c4703-c93c-46d0-8b44-57410a2f83b5",
       "name": "organisation-mapper",
       "identityProviderAlias": "Security-Company",
       "identityProviderMapper": "hardcoded-attribute-idp-mapper",
@@ -16203,7 +16109,106 @@
       }
     },
     {
-      "id": "3200e954-6228-4bd2-b7c0-bd894f4b288e",
+      "id": "6077f452-443a-405e-b0bd-a31f90b15a6a",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "Company-1",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "company-1",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "01872600-e492-4891-bf1e-a87d682f60d6",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "App-Provider",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "App-Provider",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "8f34d0e9-5f0d-46b5-a863-533493e4b5e2",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "CX-Test-Access",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "CX-Test-Access",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "b3eac58e-f6a1-45b3-aae4-99ab9a273004",
+      "name": "username-mapper",
+      "identityProviderAlias": "Company-2",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "b4908715-22a5-4d5a-85c9-aadba0edc548",
+      "name": "username-mapper",
+      "identityProviderAlias": "CX-Operator",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "63f85232-7f4b-4888-932b-af98e69a9db7",
+      "name": "username mapper",
+      "identityProviderAlias": "Security-Company",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "3ca68e56-c9ab-4532-8ade-086c06fc962b",
+      "name": "username mapper",
+      "identityProviderAlias": "CX-Test-Access",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "1194d08d-4b9d-4f03-83ec-68dba650d8c7",
+      "name": "username-mapper",
+      "identityProviderAlias": "App-Provider",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "e01bcaa1-fbfc-4069-a7d7-1dc9844e6696",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "CX-Operator",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "CX-Operator",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "aac3870c-4c68-4d2a-984a-d443ad7d253c",
       "name": "organisation-mapper",
       "identityProviderAlias": "Onboarding-Provider",
       "identityProviderMapper": "hardcoded-user-session-attribute-idp-mapper",
@@ -16211,6 +16216,39 @@
         "attribute.value": "Onboarding-Provider",
         "syncMode": "INHERIT",
         "attribute": "organisation"
+      }
+    },
+    {
+      "id": "7502ee53-a2e9-4d14-80e9-304e96489d85",
+      "name": "username-mapper",
+      "identityProviderAlias": "Service-Provider",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "00c2fd45-916e-490c-9f95-39ff539e7922",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "Company-2",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "company-2",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "c3c541ed-eed4-4b07-aa36-45457ee0fe67",
+      "name": "username-mapper",
+      "identityProviderAlias": "Company-1",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
       }
     }
   ],
@@ -16259,14 +16297,14 @@
         "subComponents": {},
         "config": {
           "allowed-protocol-mapper-types": [
-            "saml-user-property-mapper",
-            "oidc-usermodel-attribute-mapper",
-            "oidc-usermodel-property-mapper",
-            "oidc-full-name-mapper",
             "oidc-address-mapper",
             "saml-user-attribute-mapper",
+            "oidc-full-name-mapper",
+            "saml-role-list-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-usermodel-property-mapper",
             "oidc-sha256-pairwise-sub-mapper",
-            "saml-role-list-mapper"
+            "saml-user-property-mapper"
           ]
         }
       },
@@ -16287,13 +16325,13 @@
         "config": {
           "allowed-protocol-mapper-types": [
             "oidc-usermodel-attribute-mapper",
+            "saml-user-attribute-mapper",
+            "saml-role-list-mapper",
             "oidc-address-mapper",
-            "oidc-usermodel-property-mapper",
             "oidc-sha256-pairwise-sub-mapper",
             "oidc-full-name-mapper",
-            "saml-user-attribute-mapper",
-            "saml-user-property-mapper",
-            "saml-role-list-mapper"
+            "oidc-usermodel-property-mapper",
+            "saml-user-property-mapper"
           ]
         }
       },

--- a/import/realm-config/consortia/catenax-central/dev/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/dev/CX-Central-realm.json
@@ -1176,9 +1176,9 @@
                 "delete_tech_user_management",
                 "delete_own_user_account",
                 "my_user_account",
-                "unsubscribe_services",
                 "create_notifications",
                 "edit_apps",
+                "unsubscribe_services",
                 "view_apps",
                 "modify_connectors",
                 "view_use_case_participation",
@@ -1943,9 +1943,6 @@
               "Cl21-CX-DF": [
                 "view_discovery_endpoint"
               ],
-              "Cl5-CX-Custodian": [
-                "view_wallet"
-              ],
               "Cl2-CX-Portal": [
                 "view_connectors"
               ]
@@ -2548,8 +2545,8 @@
   "otpPolicyPeriod": 30,
   "otpPolicyCodeReusable": false,
   "otpSupportedApplications": [
-    "totpAppFreeOTPName",
     "totpAppMicrosoftAuthenticatorName",
+    "totpAppFreeOTPName",
     "totpAppGoogleName"
   ],
   "webAuthnPolicyRpEntityName": "keycloak",
@@ -3221,6 +3218,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3248,6 +3246,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3275,6 +3274,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3302,6 +3302,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3329,6 +3330,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3356,6 +3358,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3383,6 +3386,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3615,6 +3619,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -3647,6 +3652,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3813,6 +3819,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl5-CX-Custodian": [
@@ -3843,6 +3850,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3932,6 +3940,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -3964,6 +3973,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -3997,6 +4007,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4055,6 +4066,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4113,6 +4125,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4164,6 +4177,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4191,6 +4205,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4222,6 +4237,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4370,6 +4386,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4453,6 +4470,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4503,6 +4521,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4525,6 +4544,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4552,6 +4572,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4579,6 +4600,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4609,6 +4631,7 @@
         ],
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4995,7 +5018,8 @@
         "client": "sa-cl3-cx-1",
         "roles": [
           "Dataspace Discovery",
-          "Semantic Model Management"
+          "Semantic Model Management",
+          "Identity Wallet Management"
         ]
       }
     ],
@@ -7486,8 +7510,8 @@
         "backchannel.logout.session.required": "true",
         "client_credentials.use_refresh_token": "false",
         "saml_force_name_id_format": "false",
-        "require.pushed.authorization.requests": "false",
         "saml.client.signature": "false",
+        "require.pushed.authorization.requests": "false",
         "tls.client.certificate.bound.access.tokens": "false",
         "saml.authnstatement": "false",
         "display.on.consent.screen": "false",
@@ -15181,6 +15205,21 @@
           }
         },
         {
+          "id": "4baa14b7-833e-4bcb-a052-090e65c2bc2c",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
           "id": "1d94ee73-6981-486c-a2d8-2e2f857cd125",
           "name": "bpn-mapper",
           "protocol": "openid-connect",
@@ -16048,139 +16087,7 @@
   ],
   "identityProviderMappers": [
     {
-      "id": "6f8779b1-dda1-4803-ac46-d5c921a68219",
-      "name": "username-mapper",
-      "identityProviderAlias": "App-Provider",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "8fb729cf-2836-417b-95c5-e83f2dcf9425",
-      "name": "username-mapper",
-      "identityProviderAlias": "Service-Provider",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "64417652-af15-4e95-bebd-5cf2cec7ce0c",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "App-Provider",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "App-Provider",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "ddd0398c-c38a-48b4-b1b3-9eaa6599ac5d",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "CX-Test-Access",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "CX-Test-Access",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "6b19e978-7602-46e3-84fd-9faaa4d28c19",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "CX-Operator",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "CX-Operator",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "69d4a3f9-3e58-4efc-97f3-b4b4d633dcea",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "Company-2",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "company-2",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "f2bf3c88-2da6-4162-b354-349820707d09",
-      "name": "username-mapper",
-      "identityProviderAlias": "Company-1",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "d2d5c005-0059-4853-b64b-dad4c4bdbacb",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "Company-1",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "company-1",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "7b380535-fdb6-4766-a5e6-4405260831ba",
-      "name": "username-mapper",
-      "identityProviderAlias": "Company-2",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "cdbba93b-808f-4101-bd02-f51139ebb107",
-      "name": "username-mapper",
-      "identityProviderAlias": "CX-Operator",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "84c1924d-2208-4a55-b96a-9dfbadd9ce29",
-      "name": "username mapper",
-      "identityProviderAlias": "CX-Test-Access",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "b40269c4-a53b-42d1-8949-c20088824b68",
-      "name": "username mapper",
-      "identityProviderAlias": "Security-Company",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "9933e158-0d5b-4eea-8836-08b54be84330",
+      "id": "7698c5c5-61de-47d4-a0f7-45956bc3448b",
       "name": "organisation-mapper",
       "identityProviderAlias": "Service-Provider",
       "identityProviderMapper": "hardcoded-attribute-idp-mapper",
@@ -16191,7 +16098,7 @@
       }
     },
     {
-      "id": "3320adcc-acc2-4129-9a3c-ed10a71bee5e",
+      "id": "362c4703-c93c-46d0-8b44-57410a2f83b5",
       "name": "organisation-mapper",
       "identityProviderAlias": "Security-Company",
       "identityProviderMapper": "hardcoded-attribute-idp-mapper",
@@ -16202,7 +16109,106 @@
       }
     },
     {
-      "id": "3200e954-6228-4bd2-b7c0-bd894f4b288e",
+      "id": "6077f452-443a-405e-b0bd-a31f90b15a6a",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "Company-1",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "company-1",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "01872600-e492-4891-bf1e-a87d682f60d6",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "App-Provider",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "App-Provider",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "8f34d0e9-5f0d-46b5-a863-533493e4b5e2",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "CX-Test-Access",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "CX-Test-Access",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "b3eac58e-f6a1-45b3-aae4-99ab9a273004",
+      "name": "username-mapper",
+      "identityProviderAlias": "Company-2",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "b4908715-22a5-4d5a-85c9-aadba0edc548",
+      "name": "username-mapper",
+      "identityProviderAlias": "CX-Operator",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "63f85232-7f4b-4888-932b-af98e69a9db7",
+      "name": "username mapper",
+      "identityProviderAlias": "Security-Company",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "3ca68e56-c9ab-4532-8ade-086c06fc962b",
+      "name": "username mapper",
+      "identityProviderAlias": "CX-Test-Access",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "1194d08d-4b9d-4f03-83ec-68dba650d8c7",
+      "name": "username-mapper",
+      "identityProviderAlias": "App-Provider",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "e01bcaa1-fbfc-4069-a7d7-1dc9844e6696",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "CX-Operator",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "CX-Operator",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "aac3870c-4c68-4d2a-984a-d443ad7d253c",
       "name": "organisation-mapper",
       "identityProviderAlias": "Onboarding-Provider",
       "identityProviderMapper": "hardcoded-user-session-attribute-idp-mapper",
@@ -16210,6 +16216,39 @@
         "attribute.value": "Onboarding-Provider",
         "syncMode": "INHERIT",
         "attribute": "organisation"
+      }
+    },
+    {
+      "id": "7502ee53-a2e9-4d14-80e9-304e96489d85",
+      "name": "username-mapper",
+      "identityProviderAlias": "Service-Provider",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "00c2fd45-916e-490c-9f95-39ff539e7922",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "Company-2",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "company-2",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "c3c541ed-eed4-4b07-aa36-45457ee0fe67",
+      "name": "username-mapper",
+      "identityProviderAlias": "Company-1",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
       }
     }
   ],
@@ -16258,14 +16297,14 @@
         "subComponents": {},
         "config": {
           "allowed-protocol-mapper-types": [
-            "saml-user-property-mapper",
-            "oidc-usermodel-attribute-mapper",
-            "oidc-usermodel-property-mapper",
-            "oidc-full-name-mapper",
             "oidc-address-mapper",
             "saml-user-attribute-mapper",
+            "oidc-full-name-mapper",
+            "saml-role-list-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-usermodel-property-mapper",
             "oidc-sha256-pairwise-sub-mapper",
-            "saml-role-list-mapper"
+            "saml-user-property-mapper"
           ]
         }
       },
@@ -16286,13 +16325,13 @@
         "config": {
           "allowed-protocol-mapper-types": [
             "oidc-usermodel-attribute-mapper",
+            "saml-user-attribute-mapper",
+            "saml-role-list-mapper",
             "oidc-address-mapper",
-            "oidc-usermodel-property-mapper",
             "oidc-sha256-pairwise-sub-mapper",
             "oidc-full-name-mapper",
-            "saml-user-attribute-mapper",
-            "saml-user-property-mapper",
-            "saml-role-list-mapper"
+            "oidc-usermodel-property-mapper",
+            "saml-user-property-mapper"
           ]
         }
       },

--- a/import/realm-config/consortia/catenax-central/int/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/int/CX-Central-realm.json
@@ -1176,9 +1176,9 @@
                 "delete_tech_user_management",
                 "delete_own_user_account",
                 "my_user_account",
-                "unsubscribe_services",
                 "create_notifications",
                 "edit_apps",
+                "unsubscribe_services",
                 "view_apps",
                 "modify_connectors",
                 "view_use_case_participation",
@@ -1943,9 +1943,6 @@
               "Cl21-CX-DF": [
                 "view_discovery_endpoint"
               ],
-              "Cl5-CX-Custodian": [
-                "view_wallet"
-              ],
               "Cl2-CX-Portal": [
                 "view_connectors"
               ]
@@ -2548,9 +2545,9 @@
   "otpPolicyPeriod": 30,
   "otpPolicyCodeReusable": false,
   "otpSupportedApplications": [
-    "totpAppGoogleName",
     "totpAppMicrosoftAuthenticatorName",
-    "totpAppFreeOTPName"
+    "totpAppFreeOTPName",
+    "totpAppGoogleName"
   ],
   "webAuthnPolicyRpEntityName": "keycloak",
   "webAuthnPolicySignatureAlgorithms": [
@@ -3221,6 +3218,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3248,6 +3246,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3275,6 +3274,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3302,6 +3302,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3329,6 +3330,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3356,6 +3358,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3383,6 +3386,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3615,6 +3619,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -3647,6 +3652,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3813,6 +3819,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl5-CX-Custodian": [
@@ -3843,6 +3850,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3932,6 +3940,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -3964,6 +3973,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -3997,6 +4007,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4055,6 +4066,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4113,6 +4125,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4164,6 +4177,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4191,6 +4205,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4222,6 +4237,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4370,6 +4386,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4453,6 +4470,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4503,6 +4521,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4525,6 +4544,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4552,6 +4572,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4579,6 +4600,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4609,6 +4631,7 @@
         ],
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4995,7 +5018,8 @@
         "client": "sa-cl3-cx-1",
         "roles": [
           "Dataspace Discovery",
-          "Semantic Model Management"
+          "Semantic Model Management",
+          "Identity Wallet Management"
         ]
       }
     ],
@@ -7486,8 +7510,8 @@
         "backchannel.logout.session.required": "true",
         "client_credentials.use_refresh_token": "false",
         "saml_force_name_id_format": "false",
-        "require.pushed.authorization.requests": "false",
         "saml.client.signature": "false",
+        "require.pushed.authorization.requests": "false",
         "tls.client.certificate.bound.access.tokens": "false",
         "saml.authnstatement": "false",
         "display.on.consent.screen": "false",
@@ -15181,6 +15205,21 @@
           }
         },
         {
+          "id": "4baa14b7-833e-4bcb-a052-090e65c2bc2c",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
           "id": "1d94ee73-6981-486c-a2d8-2e2f857cd125",
           "name": "bpn-mapper",
           "protocol": "openid-connect",
@@ -15331,7 +15370,6 @@
           "protocolMapper": "oidc-address-mapper",
           "consentRequired": false,
           "config": {
-            "user.attribute.formatted": "formatted",
             "user.attribute.country": "country",
             "user.attribute.postal_code": "postal_code",
             "userinfo.token.claim": "true",
@@ -16049,139 +16087,7 @@
   ],
   "identityProviderMappers": [
     {
-      "id": "6f8779b1-dda1-4803-ac46-d5c921a68219",
-      "name": "username-mapper",
-      "identityProviderAlias": "App-Provider",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "8fb729cf-2836-417b-95c5-e83f2dcf9425",
-      "name": "username-mapper",
-      "identityProviderAlias": "Service-Provider",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "64417652-af15-4e95-bebd-5cf2cec7ce0c",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "App-Provider",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "App-Provider",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "ddd0398c-c38a-48b4-b1b3-9eaa6599ac5d",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "CX-Test-Access",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "CX-Test-Access",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "6b19e978-7602-46e3-84fd-9faaa4d28c19",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "CX-Operator",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "CX-Operator",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "69d4a3f9-3e58-4efc-97f3-b4b4d633dcea",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "Company-2",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "company-2",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "f2bf3c88-2da6-4162-b354-349820707d09",
-      "name": "username-mapper",
-      "identityProviderAlias": "Company-1",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "d2d5c005-0059-4853-b64b-dad4c4bdbacb",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "Company-1",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "company-1",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "7b380535-fdb6-4766-a5e6-4405260831ba",
-      "name": "username-mapper",
-      "identityProviderAlias": "Company-2",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "cdbba93b-808f-4101-bd02-f51139ebb107",
-      "name": "username-mapper",
-      "identityProviderAlias": "CX-Operator",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "84c1924d-2208-4a55-b96a-9dfbadd9ce29",
-      "name": "username mapper",
-      "identityProviderAlias": "CX-Test-Access",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "b40269c4-a53b-42d1-8949-c20088824b68",
-      "name": "username mapper",
-      "identityProviderAlias": "Security-Company",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "9933e158-0d5b-4eea-8836-08b54be84330",
+      "id": "7698c5c5-61de-47d4-a0f7-45956bc3448b",
       "name": "organisation-mapper",
       "identityProviderAlias": "Service-Provider",
       "identityProviderMapper": "hardcoded-attribute-idp-mapper",
@@ -16192,7 +16098,7 @@
       }
     },
     {
-      "id": "3320adcc-acc2-4129-9a3c-ed10a71bee5e",
+      "id": "362c4703-c93c-46d0-8b44-57410a2f83b5",
       "name": "organisation-mapper",
       "identityProviderAlias": "Security-Company",
       "identityProviderMapper": "hardcoded-attribute-idp-mapper",
@@ -16203,7 +16109,106 @@
       }
     },
     {
-      "id": "3200e954-6228-4bd2-b7c0-bd894f4b288e",
+      "id": "6077f452-443a-405e-b0bd-a31f90b15a6a",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "Company-1",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "company-1",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "01872600-e492-4891-bf1e-a87d682f60d6",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "App-Provider",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "App-Provider",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "8f34d0e9-5f0d-46b5-a863-533493e4b5e2",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "CX-Test-Access",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "CX-Test-Access",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "b3eac58e-f6a1-45b3-aae4-99ab9a273004",
+      "name": "username-mapper",
+      "identityProviderAlias": "Company-2",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "b4908715-22a5-4d5a-85c9-aadba0edc548",
+      "name": "username-mapper",
+      "identityProviderAlias": "CX-Operator",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "63f85232-7f4b-4888-932b-af98e69a9db7",
+      "name": "username mapper",
+      "identityProviderAlias": "Security-Company",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "3ca68e56-c9ab-4532-8ade-086c06fc962b",
+      "name": "username mapper",
+      "identityProviderAlias": "CX-Test-Access",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "1194d08d-4b9d-4f03-83ec-68dba650d8c7",
+      "name": "username-mapper",
+      "identityProviderAlias": "App-Provider",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "e01bcaa1-fbfc-4069-a7d7-1dc9844e6696",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "CX-Operator",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "CX-Operator",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "aac3870c-4c68-4d2a-984a-d443ad7d253c",
       "name": "organisation-mapper",
       "identityProviderAlias": "Onboarding-Provider",
       "identityProviderMapper": "hardcoded-user-session-attribute-idp-mapper",
@@ -16211,6 +16216,39 @@
         "attribute.value": "Onboarding-Provider",
         "syncMode": "INHERIT",
         "attribute": "organisation"
+      }
+    },
+    {
+      "id": "7502ee53-a2e9-4d14-80e9-304e96489d85",
+      "name": "username-mapper",
+      "identityProviderAlias": "Service-Provider",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "00c2fd45-916e-490c-9f95-39ff539e7922",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "Company-2",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "company-2",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "c3c541ed-eed4-4b07-aa36-45457ee0fe67",
+      "name": "username-mapper",
+      "identityProviderAlias": "Company-1",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
       }
     }
   ],
@@ -16259,14 +16297,14 @@
         "subComponents": {},
         "config": {
           "allowed-protocol-mapper-types": [
-            "saml-user-property-mapper",
-            "oidc-usermodel-attribute-mapper",
-            "oidc-usermodel-property-mapper",
-            "oidc-full-name-mapper",
             "oidc-address-mapper",
             "saml-user-attribute-mapper",
+            "oidc-full-name-mapper",
+            "saml-role-list-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-usermodel-property-mapper",
             "oidc-sha256-pairwise-sub-mapper",
-            "saml-role-list-mapper"
+            "saml-user-property-mapper"
           ]
         }
       },
@@ -16287,13 +16325,13 @@
         "config": {
           "allowed-protocol-mapper-types": [
             "oidc-usermodel-attribute-mapper",
+            "saml-user-attribute-mapper",
+            "saml-role-list-mapper",
             "oidc-address-mapper",
-            "oidc-usermodel-property-mapper",
             "oidc-sha256-pairwise-sub-mapper",
             "oidc-full-name-mapper",
-            "saml-user-attribute-mapper",
-            "saml-user-property-mapper",
-            "saml-role-list-mapper"
+            "oidc-usermodel-property-mapper",
+            "saml-user-property-mapper"
           ]
         }
       },

--- a/import/realm-config/consortia/catenax-central/pen/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/pen/CX-Central-realm.json
@@ -1176,9 +1176,9 @@
                 "delete_tech_user_management",
                 "delete_own_user_account",
                 "my_user_account",
-                "unsubscribe_services",
                 "create_notifications",
                 "edit_apps",
+                "unsubscribe_services",
                 "view_apps",
                 "modify_connectors",
                 "view_use_case_participation",
@@ -1943,9 +1943,6 @@
               "Cl21-CX-DF": [
                 "view_discovery_endpoint"
               ],
-              "Cl5-CX-Custodian": [
-                "view_wallet"
-              ],
               "Cl2-CX-Portal": [
                 "view_connectors"
               ]
@@ -2548,9 +2545,9 @@
   "otpPolicyPeriod": 30,
   "otpPolicyCodeReusable": false,
   "otpSupportedApplications": [
-    "totpAppGoogleName",
     "totpAppMicrosoftAuthenticatorName",
-    "totpAppFreeOTPName"
+    "totpAppFreeOTPName",
+    "totpAppGoogleName"
   ],
   "webAuthnPolicyRpEntityName": "keycloak",
   "webAuthnPolicySignatureAlgorithms": [
@@ -3221,6 +3218,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3248,6 +3246,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3275,6 +3274,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3302,6 +3302,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3329,6 +3330,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3356,6 +3358,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3383,6 +3386,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3615,6 +3619,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -3647,6 +3652,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3813,6 +3819,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl5-CX-Custodian": [
@@ -3843,6 +3850,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3932,6 +3940,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -3964,6 +3973,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -3997,6 +4007,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4055,6 +4066,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4113,6 +4125,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4164,6 +4177,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4191,6 +4205,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4222,6 +4237,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4370,6 +4386,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4453,6 +4470,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4503,6 +4521,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4525,6 +4544,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4552,6 +4572,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4579,6 +4600,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4609,6 +4631,7 @@
         ],
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4995,7 +5018,8 @@
         "client": "sa-cl3-cx-1",
         "roles": [
           "Dataspace Discovery",
-          "Semantic Model Management"
+          "Semantic Model Management",
+          "Identity Wallet Management"
         ]
       }
     ],
@@ -7486,8 +7510,8 @@
         "backchannel.logout.session.required": "true",
         "client_credentials.use_refresh_token": "false",
         "saml_force_name_id_format": "false",
-        "require.pushed.authorization.requests": "false",
         "saml.client.signature": "false",
+        "require.pushed.authorization.requests": "false",
         "tls.client.certificate.bound.access.tokens": "false",
         "saml.authnstatement": "false",
         "display.on.consent.screen": "false",
@@ -15181,6 +15205,21 @@
           }
         },
         {
+          "id": "4baa14b7-833e-4bcb-a052-090e65c2bc2c",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
           "id": "1d94ee73-6981-486c-a2d8-2e2f857cd125",
           "name": "bpn-mapper",
           "protocol": "openid-connect",
@@ -15331,7 +15370,6 @@
           "protocolMapper": "oidc-address-mapper",
           "consentRequired": false,
           "config": {
-            "user.attribute.formatted": "formatted",
             "user.attribute.country": "country",
             "user.attribute.postal_code": "postal_code",
             "userinfo.token.claim": "true",
@@ -16049,139 +16087,7 @@
   ],
   "identityProviderMappers": [
     {
-      "id": "6f8779b1-dda1-4803-ac46-d5c921a68219",
-      "name": "username-mapper",
-      "identityProviderAlias": "App-Provider",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "8fb729cf-2836-417b-95c5-e83f2dcf9425",
-      "name": "username-mapper",
-      "identityProviderAlias": "Service-Provider",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "64417652-af15-4e95-bebd-5cf2cec7ce0c",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "App-Provider",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "App-Provider",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "ddd0398c-c38a-48b4-b1b3-9eaa6599ac5d",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "CX-Test-Access",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "CX-Test-Access",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "6b19e978-7602-46e3-84fd-9faaa4d28c19",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "CX-Operator",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "CX-Operator",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "69d4a3f9-3e58-4efc-97f3-b4b4d633dcea",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "Company-2",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "company-2",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "f2bf3c88-2da6-4162-b354-349820707d09",
-      "name": "username-mapper",
-      "identityProviderAlias": "Company-1",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "d2d5c005-0059-4853-b64b-dad4c4bdbacb",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "Company-1",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "company-1",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "7b380535-fdb6-4766-a5e6-4405260831ba",
-      "name": "username-mapper",
-      "identityProviderAlias": "Company-2",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "cdbba93b-808f-4101-bd02-f51139ebb107",
-      "name": "username-mapper",
-      "identityProviderAlias": "CX-Operator",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "84c1924d-2208-4a55-b96a-9dfbadd9ce29",
-      "name": "username mapper",
-      "identityProviderAlias": "CX-Test-Access",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "b40269c4-a53b-42d1-8949-c20088824b68",
-      "name": "username mapper",
-      "identityProviderAlias": "Security-Company",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "9933e158-0d5b-4eea-8836-08b54be84330",
+      "id": "7698c5c5-61de-47d4-a0f7-45956bc3448b",
       "name": "organisation-mapper",
       "identityProviderAlias": "Service-Provider",
       "identityProviderMapper": "hardcoded-attribute-idp-mapper",
@@ -16192,7 +16098,7 @@
       }
     },
     {
-      "id": "3320adcc-acc2-4129-9a3c-ed10a71bee5e",
+      "id": "362c4703-c93c-46d0-8b44-57410a2f83b5",
       "name": "organisation-mapper",
       "identityProviderAlias": "Security-Company",
       "identityProviderMapper": "hardcoded-attribute-idp-mapper",
@@ -16203,7 +16109,106 @@
       }
     },
     {
-      "id": "3200e954-6228-4bd2-b7c0-bd894f4b288e",
+      "id": "6077f452-443a-405e-b0bd-a31f90b15a6a",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "Company-1",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "company-1",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "01872600-e492-4891-bf1e-a87d682f60d6",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "App-Provider",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "App-Provider",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "8f34d0e9-5f0d-46b5-a863-533493e4b5e2",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "CX-Test-Access",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "CX-Test-Access",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "b3eac58e-f6a1-45b3-aae4-99ab9a273004",
+      "name": "username-mapper",
+      "identityProviderAlias": "Company-2",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "b4908715-22a5-4d5a-85c9-aadba0edc548",
+      "name": "username-mapper",
+      "identityProviderAlias": "CX-Operator",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "63f85232-7f4b-4888-932b-af98e69a9db7",
+      "name": "username mapper",
+      "identityProviderAlias": "Security-Company",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "3ca68e56-c9ab-4532-8ade-086c06fc962b",
+      "name": "username mapper",
+      "identityProviderAlias": "CX-Test-Access",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "1194d08d-4b9d-4f03-83ec-68dba650d8c7",
+      "name": "username-mapper",
+      "identityProviderAlias": "App-Provider",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "e01bcaa1-fbfc-4069-a7d7-1dc9844e6696",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "CX-Operator",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "CX-Operator",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "aac3870c-4c68-4d2a-984a-d443ad7d253c",
       "name": "organisation-mapper",
       "identityProviderAlias": "Onboarding-Provider",
       "identityProviderMapper": "hardcoded-user-session-attribute-idp-mapper",
@@ -16211,6 +16216,39 @@
         "attribute.value": "Onboarding-Provider",
         "syncMode": "INHERIT",
         "attribute": "organisation"
+      }
+    },
+    {
+      "id": "7502ee53-a2e9-4d14-80e9-304e96489d85",
+      "name": "username-mapper",
+      "identityProviderAlias": "Service-Provider",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "00c2fd45-916e-490c-9f95-39ff539e7922",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "Company-2",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "company-2",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "c3c541ed-eed4-4b07-aa36-45457ee0fe67",
+      "name": "username-mapper",
+      "identityProviderAlias": "Company-1",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
       }
     }
   ],
@@ -16259,14 +16297,14 @@
         "subComponents": {},
         "config": {
           "allowed-protocol-mapper-types": [
-            "saml-user-property-mapper",
-            "oidc-usermodel-attribute-mapper",
-            "oidc-usermodel-property-mapper",
-            "oidc-full-name-mapper",
             "oidc-address-mapper",
             "saml-user-attribute-mapper",
+            "oidc-full-name-mapper",
+            "saml-role-list-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-usermodel-property-mapper",
             "oidc-sha256-pairwise-sub-mapper",
-            "saml-role-list-mapper"
+            "saml-user-property-mapper"
           ]
         }
       },
@@ -16287,13 +16325,13 @@
         "config": {
           "allowed-protocol-mapper-types": [
             "oidc-usermodel-attribute-mapper",
+            "saml-user-attribute-mapper",
+            "saml-role-list-mapper",
             "oidc-address-mapper",
-            "oidc-usermodel-property-mapper",
             "oidc-sha256-pairwise-sub-mapper",
             "oidc-full-name-mapper",
-            "saml-user-attribute-mapper",
-            "saml-user-property-mapper",
-            "saml-role-list-mapper"
+            "oidc-usermodel-property-mapper",
+            "saml-user-property-mapper"
           ]
         }
       },

--- a/import/realm-config/consortia/catenax-central/rc/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/rc/CX-Central-realm.json
@@ -1176,9 +1176,9 @@
                 "delete_tech_user_management",
                 "delete_own_user_account",
                 "my_user_account",
-                "unsubscribe_services",
                 "create_notifications",
                 "edit_apps",
+                "unsubscribe_services",
                 "view_apps",
                 "modify_connectors",
                 "view_use_case_participation",
@@ -1943,9 +1943,6 @@
               "Cl21-CX-DF": [
                 "view_discovery_endpoint"
               ],
-              "Cl5-CX-Custodian": [
-                "view_wallet"
-              ],
               "Cl2-CX-Portal": [
                 "view_connectors"
               ]
@@ -2548,9 +2545,9 @@
   "otpPolicyPeriod": 30,
   "otpPolicyCodeReusable": false,
   "otpSupportedApplications": [
-    "totpAppGoogleName",
     "totpAppMicrosoftAuthenticatorName",
-    "totpAppFreeOTPName"
+    "totpAppFreeOTPName",
+    "totpAppGoogleName"
   ],
   "webAuthnPolicyRpEntityName": "keycloak",
   "webAuthnPolicySignatureAlgorithms": [
@@ -3221,6 +3218,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3248,6 +3246,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3275,6 +3274,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3302,6 +3302,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3329,6 +3330,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3356,6 +3358,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3383,6 +3386,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3615,6 +3619,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -3647,6 +3652,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3813,6 +3819,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl5-CX-Custodian": [
@@ -3843,6 +3850,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3932,6 +3940,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -3964,6 +3973,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -3997,6 +4007,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4055,6 +4066,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4113,6 +4125,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4164,6 +4177,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4191,6 +4205,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4222,6 +4237,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4370,6 +4386,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4453,6 +4470,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4503,6 +4521,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4525,6 +4544,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4552,6 +4572,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4579,6 +4600,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4609,6 +4631,7 @@
         ],
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4995,7 +5018,8 @@
         "client": "sa-cl3-cx-1",
         "roles": [
           "Dataspace Discovery",
-          "Semantic Model Management"
+          "Semantic Model Management",
+          "Identity Wallet Management"
         ]
       }
     ],
@@ -7486,8 +7510,8 @@
         "backchannel.logout.session.required": "true",
         "client_credentials.use_refresh_token": "false",
         "saml_force_name_id_format": "false",
-        "require.pushed.authorization.requests": "false",
         "saml.client.signature": "false",
+        "require.pushed.authorization.requests": "false",
         "tls.client.certificate.bound.access.tokens": "false",
         "saml.authnstatement": "false",
         "display.on.consent.screen": "false",
@@ -15181,6 +15205,21 @@
           }
         },
         {
+          "id": "4baa14b7-833e-4bcb-a052-090e65c2bc2c",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
           "id": "1d94ee73-6981-486c-a2d8-2e2f857cd125",
           "name": "bpn-mapper",
           "protocol": "openid-connect",
@@ -15331,7 +15370,6 @@
           "protocolMapper": "oidc-address-mapper",
           "consentRequired": false,
           "config": {
-            "user.attribute.formatted": "formatted",
             "user.attribute.country": "country",
             "user.attribute.postal_code": "postal_code",
             "userinfo.token.claim": "true",
@@ -16049,139 +16087,7 @@
   ],
   "identityProviderMappers": [
     {
-      "id": "6f8779b1-dda1-4803-ac46-d5c921a68219",
-      "name": "username-mapper",
-      "identityProviderAlias": "App-Provider",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "8fb729cf-2836-417b-95c5-e83f2dcf9425",
-      "name": "username-mapper",
-      "identityProviderAlias": "Service-Provider",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "64417652-af15-4e95-bebd-5cf2cec7ce0c",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "App-Provider",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "App-Provider",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "ddd0398c-c38a-48b4-b1b3-9eaa6599ac5d",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "CX-Test-Access",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "CX-Test-Access",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "6b19e978-7602-46e3-84fd-9faaa4d28c19",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "CX-Operator",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "CX-Operator",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "69d4a3f9-3e58-4efc-97f3-b4b4d633dcea",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "Company-2",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "company-2",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "f2bf3c88-2da6-4162-b354-349820707d09",
-      "name": "username-mapper",
-      "identityProviderAlias": "Company-1",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "d2d5c005-0059-4853-b64b-dad4c4bdbacb",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "Company-1",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "company-1",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "7b380535-fdb6-4766-a5e6-4405260831ba",
-      "name": "username-mapper",
-      "identityProviderAlias": "Company-2",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "cdbba93b-808f-4101-bd02-f51139ebb107",
-      "name": "username-mapper",
-      "identityProviderAlias": "CX-Operator",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "84c1924d-2208-4a55-b96a-9dfbadd9ce29",
-      "name": "username mapper",
-      "identityProviderAlias": "CX-Test-Access",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "b40269c4-a53b-42d1-8949-c20088824b68",
-      "name": "username mapper",
-      "identityProviderAlias": "Security-Company",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "9933e158-0d5b-4eea-8836-08b54be84330",
+      "id": "7698c5c5-61de-47d4-a0f7-45956bc3448b",
       "name": "organisation-mapper",
       "identityProviderAlias": "Service-Provider",
       "identityProviderMapper": "hardcoded-attribute-idp-mapper",
@@ -16192,7 +16098,7 @@
       }
     },
     {
-      "id": "3320adcc-acc2-4129-9a3c-ed10a71bee5e",
+      "id": "362c4703-c93c-46d0-8b44-57410a2f83b5",
       "name": "organisation-mapper",
       "identityProviderAlias": "Security-Company",
       "identityProviderMapper": "hardcoded-attribute-idp-mapper",
@@ -16203,7 +16109,106 @@
       }
     },
     {
-      "id": "3200e954-6228-4bd2-b7c0-bd894f4b288e",
+      "id": "6077f452-443a-405e-b0bd-a31f90b15a6a",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "Company-1",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "company-1",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "01872600-e492-4891-bf1e-a87d682f60d6",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "App-Provider",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "App-Provider",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "8f34d0e9-5f0d-46b5-a863-533493e4b5e2",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "CX-Test-Access",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "CX-Test-Access",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "b3eac58e-f6a1-45b3-aae4-99ab9a273004",
+      "name": "username-mapper",
+      "identityProviderAlias": "Company-2",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "b4908715-22a5-4d5a-85c9-aadba0edc548",
+      "name": "username-mapper",
+      "identityProviderAlias": "CX-Operator",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "63f85232-7f4b-4888-932b-af98e69a9db7",
+      "name": "username mapper",
+      "identityProviderAlias": "Security-Company",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "3ca68e56-c9ab-4532-8ade-086c06fc962b",
+      "name": "username mapper",
+      "identityProviderAlias": "CX-Test-Access",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "1194d08d-4b9d-4f03-83ec-68dba650d8c7",
+      "name": "username-mapper",
+      "identityProviderAlias": "App-Provider",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "e01bcaa1-fbfc-4069-a7d7-1dc9844e6696",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "CX-Operator",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "CX-Operator",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "aac3870c-4c68-4d2a-984a-d443ad7d253c",
       "name": "organisation-mapper",
       "identityProviderAlias": "Onboarding-Provider",
       "identityProviderMapper": "hardcoded-user-session-attribute-idp-mapper",
@@ -16211,6 +16216,39 @@
         "attribute.value": "Onboarding-Provider",
         "syncMode": "INHERIT",
         "attribute": "organisation"
+      }
+    },
+    {
+      "id": "7502ee53-a2e9-4d14-80e9-304e96489d85",
+      "name": "username-mapper",
+      "identityProviderAlias": "Service-Provider",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "00c2fd45-916e-490c-9f95-39ff539e7922",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "Company-2",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "company-2",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "c3c541ed-eed4-4b07-aa36-45457ee0fe67",
+      "name": "username-mapper",
+      "identityProviderAlias": "Company-1",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
       }
     }
   ],
@@ -16259,14 +16297,14 @@
         "subComponents": {},
         "config": {
           "allowed-protocol-mapper-types": [
-            "saml-user-property-mapper",
-            "oidc-usermodel-attribute-mapper",
-            "oidc-usermodel-property-mapper",
-            "oidc-full-name-mapper",
             "oidc-address-mapper",
             "saml-user-attribute-mapper",
+            "oidc-full-name-mapper",
+            "saml-role-list-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-usermodel-property-mapper",
             "oidc-sha256-pairwise-sub-mapper",
-            "saml-role-list-mapper"
+            "saml-user-property-mapper"
           ]
         }
       },
@@ -16287,13 +16325,13 @@
         "config": {
           "allowed-protocol-mapper-types": [
             "oidc-usermodel-attribute-mapper",
+            "saml-user-attribute-mapper",
+            "saml-role-list-mapper",
             "oidc-address-mapper",
-            "oidc-usermodel-property-mapper",
             "oidc-sha256-pairwise-sub-mapper",
             "oidc-full-name-mapper",
-            "saml-user-attribute-mapper",
-            "saml-user-property-mapper",
-            "saml-role-list-mapper"
+            "oidc-usermodel-property-mapper",
+            "saml-user-property-mapper"
           ]
         }
       },

--- a/import/realm-config/consortia/catenax-central/stable/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/stable/CX-Central-realm.json
@@ -1176,9 +1176,9 @@
                 "delete_tech_user_management",
                 "delete_own_user_account",
                 "my_user_account",
-                "unsubscribe_services",
                 "create_notifications",
                 "edit_apps",
+                "unsubscribe_services",
                 "view_apps",
                 "modify_connectors",
                 "view_use_case_participation",
@@ -1943,9 +1943,6 @@
               "Cl21-CX-DF": [
                 "view_discovery_endpoint"
               ],
-              "Cl5-CX-Custodian": [
-                "view_wallet"
-              ],
               "Cl2-CX-Portal": [
                 "view_connectors"
               ]
@@ -2548,9 +2545,9 @@
   "otpPolicyPeriod": 30,
   "otpPolicyCodeReusable": false,
   "otpSupportedApplications": [
-    "totpAppGoogleName",
     "totpAppMicrosoftAuthenticatorName",
-    "totpAppFreeOTPName"
+    "totpAppFreeOTPName",
+    "totpAppGoogleName"
   ],
   "webAuthnPolicyRpEntityName": "keycloak",
   "webAuthnPolicySignatureAlgorithms": [
@@ -3221,6 +3218,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3248,6 +3246,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3275,6 +3274,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3302,6 +3302,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3329,6 +3330,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3356,6 +3358,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3383,6 +3386,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3615,6 +3619,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -3647,6 +3652,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3813,6 +3819,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl5-CX-Custodian": [
@@ -3843,6 +3850,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -3932,6 +3940,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -3964,6 +3973,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -3997,6 +4007,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4055,6 +4066,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4113,6 +4125,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4164,6 +4177,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4191,6 +4205,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4222,6 +4237,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4370,6 +4386,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4453,6 +4470,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4503,6 +4521,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4525,6 +4544,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4552,6 +4572,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4579,6 +4600,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ]
       },
@@ -4609,6 +4631,7 @@
         ],
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -4995,7 +5018,8 @@
         "client": "sa-cl3-cx-1",
         "roles": [
           "Dataspace Discovery",
-          "Semantic Model Management"
+          "Semantic Model Management",
+          "Identity Wallet Management"
         ]
       }
     ],
@@ -7486,8 +7510,8 @@
         "backchannel.logout.session.required": "true",
         "client_credentials.use_refresh_token": "false",
         "saml_force_name_id_format": "false",
-        "require.pushed.authorization.requests": "false",
         "saml.client.signature": "false",
+        "require.pushed.authorization.requests": "false",
         "tls.client.certificate.bound.access.tokens": "false",
         "saml.authnstatement": "false",
         "display.on.consent.screen": "false",
@@ -15181,6 +15205,21 @@
           }
         },
         {
+          "id": "4baa14b7-833e-4bcb-a052-090e65c2bc2c",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
           "id": "1d94ee73-6981-486c-a2d8-2e2f857cd125",
           "name": "bpn-mapper",
           "protocol": "openid-connect",
@@ -15331,7 +15370,6 @@
           "protocolMapper": "oidc-address-mapper",
           "consentRequired": false,
           "config": {
-            "user.attribute.formatted": "formatted",
             "user.attribute.country": "country",
             "user.attribute.postal_code": "postal_code",
             "userinfo.token.claim": "true",
@@ -16049,139 +16087,7 @@
   ],
   "identityProviderMappers": [
     {
-      "id": "6f8779b1-dda1-4803-ac46-d5c921a68219",
-      "name": "username-mapper",
-      "identityProviderAlias": "App-Provider",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "8fb729cf-2836-417b-95c5-e83f2dcf9425",
-      "name": "username-mapper",
-      "identityProviderAlias": "Service-Provider",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "64417652-af15-4e95-bebd-5cf2cec7ce0c",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "App-Provider",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "App-Provider",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "ddd0398c-c38a-48b4-b1b3-9eaa6599ac5d",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "CX-Test-Access",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "CX-Test-Access",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "6b19e978-7602-46e3-84fd-9faaa4d28c19",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "CX-Operator",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "CX-Operator",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "69d4a3f9-3e58-4efc-97f3-b4b4d633dcea",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "Company-2",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "company-2",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "f2bf3c88-2da6-4162-b354-349820707d09",
-      "name": "username-mapper",
-      "identityProviderAlias": "Company-1",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "d2d5c005-0059-4853-b64b-dad4c4bdbacb",
-      "name": "organisation-mapper",
-      "identityProviderAlias": "Company-1",
-      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
-      "config": {
-        "attribute.value": "company-1",
-        "syncMode": "INHERIT",
-        "attribute": "organisation"
-      }
-    },
-    {
-      "id": "7b380535-fdb6-4766-a5e6-4405260831ba",
-      "name": "username-mapper",
-      "identityProviderAlias": "Company-2",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "cdbba93b-808f-4101-bd02-f51139ebb107",
-      "name": "username-mapper",
-      "identityProviderAlias": "CX-Operator",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "84c1924d-2208-4a55-b96a-9dfbadd9ce29",
-      "name": "username mapper",
-      "identityProviderAlias": "CX-Test-Access",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "b40269c4-a53b-42d1-8949-c20088824b68",
-      "name": "username mapper",
-      "identityProviderAlias": "Security-Company",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "9933e158-0d5b-4eea-8836-08b54be84330",
+      "id": "7698c5c5-61de-47d4-a0f7-45956bc3448b",
       "name": "organisation-mapper",
       "identityProviderAlias": "Service-Provider",
       "identityProviderMapper": "hardcoded-attribute-idp-mapper",
@@ -16192,7 +16098,7 @@
       }
     },
     {
-      "id": "3320adcc-acc2-4129-9a3c-ed10a71bee5e",
+      "id": "362c4703-c93c-46d0-8b44-57410a2f83b5",
       "name": "organisation-mapper",
       "identityProviderAlias": "Security-Company",
       "identityProviderMapper": "hardcoded-attribute-idp-mapper",
@@ -16203,7 +16109,106 @@
       }
     },
     {
-      "id": "3200e954-6228-4bd2-b7c0-bd894f4b288e",
+      "id": "6077f452-443a-405e-b0bd-a31f90b15a6a",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "Company-1",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "company-1",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "01872600-e492-4891-bf1e-a87d682f60d6",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "App-Provider",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "App-Provider",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "8f34d0e9-5f0d-46b5-a863-533493e4b5e2",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "CX-Test-Access",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "CX-Test-Access",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "b3eac58e-f6a1-45b3-aae4-99ab9a273004",
+      "name": "username-mapper",
+      "identityProviderAlias": "Company-2",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "b4908715-22a5-4d5a-85c9-aadba0edc548",
+      "name": "username-mapper",
+      "identityProviderAlias": "CX-Operator",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "63f85232-7f4b-4888-932b-af98e69a9db7",
+      "name": "username mapper",
+      "identityProviderAlias": "Security-Company",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "3ca68e56-c9ab-4532-8ade-086c06fc962b",
+      "name": "username mapper",
+      "identityProviderAlias": "CX-Test-Access",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "1194d08d-4b9d-4f03-83ec-68dba650d8c7",
+      "name": "username-mapper",
+      "identityProviderAlias": "App-Provider",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "e01bcaa1-fbfc-4069-a7d7-1dc9844e6696",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "CX-Operator",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "CX-Operator",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "aac3870c-4c68-4d2a-984a-d443ad7d253c",
       "name": "organisation-mapper",
       "identityProviderAlias": "Onboarding-Provider",
       "identityProviderMapper": "hardcoded-user-session-attribute-idp-mapper",
@@ -16211,6 +16216,39 @@
         "attribute.value": "Onboarding-Provider",
         "syncMode": "INHERIT",
         "attribute": "organisation"
+      }
+    },
+    {
+      "id": "7502ee53-a2e9-4d14-80e9-304e96489d85",
+      "name": "username-mapper",
+      "identityProviderAlias": "Service-Provider",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
+      }
+    },
+    {
+      "id": "00c2fd45-916e-490c-9f95-39ff539e7922",
+      "name": "organisation-mapper",
+      "identityProviderAlias": "Company-2",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "company-2",
+        "syncMode": "INHERIT",
+        "attribute": "organisation"
+      }
+    },
+    {
+      "id": "c3c541ed-eed4-4b07-aa36-45457ee0fe67",
+      "name": "username-mapper",
+      "identityProviderAlias": "Company-1",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
       }
     }
   ],
@@ -16259,14 +16297,14 @@
         "subComponents": {},
         "config": {
           "allowed-protocol-mapper-types": [
-            "saml-user-property-mapper",
-            "oidc-usermodel-attribute-mapper",
-            "oidc-usermodel-property-mapper",
-            "oidc-full-name-mapper",
             "oidc-address-mapper",
             "saml-user-attribute-mapper",
+            "oidc-full-name-mapper",
+            "saml-role-list-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-usermodel-property-mapper",
             "oidc-sha256-pairwise-sub-mapper",
-            "saml-role-list-mapper"
+            "saml-user-property-mapper"
           ]
         }
       },
@@ -16287,13 +16325,13 @@
         "config": {
           "allowed-protocol-mapper-types": [
             "oidc-usermodel-attribute-mapper",
+            "saml-user-attribute-mapper",
+            "saml-role-list-mapper",
             "oidc-address-mapper",
-            "oidc-usermodel-property-mapper",
             "oidc-sha256-pairwise-sub-mapper",
             "oidc-full-name-mapper",
-            "saml-user-attribute-mapper",
-            "saml-user-property-mapper",
-            "saml-role-list-mapper"
+            "oidc-usermodel-property-mapper",
+            "saml-user-property-mapper"
           ]
         }
       },

--- a/import/realm-config/generic/catenax-central/CX-Central-realm.json
+++ b/import/realm-config/generic/catenax-central/CX-Central-realm.json
@@ -1170,9 +1170,9 @@
                 "delete_tech_user_management",
                 "delete_own_user_account",
                 "my_user_account",
-                "unsubscribe_services",
                 "create_notifications",
                 "edit_apps",
+                "unsubscribe_services",
                 "view_apps",
                 "modify_connectors",
                 "view_use_case_participation",
@@ -1523,9 +1523,6 @@
               ],
               "Cl21-CX-DF": [
                 "view_discovery_endpoint"
-              ],
-              "Cl5-CX-Custodian": [
-                "view_wallet"
               ],
               "Cl2-CX-Portal": [
                 "view_connectors"
@@ -2187,8 +2184,8 @@
   "otpPolicyPeriod": 30,
   "otpPolicyCodeReusable": false,
   "otpSupportedApplications": [
-    "totpAppMicrosoftAuthenticatorName",
     "totpAppGoogleName",
+    "totpAppMicrosoftAuthenticatorName",
     "totpAppFreeOTPName"
   ],
   "webAuthnPolicyRpEntityName": "keycloak",
@@ -2334,8 +2331,6 @@
       "enabled": true,
       "totp": false,
       "emailVerified": false,
-      "firstName": "",
-      "lastName": "",
       "serviceAccountClientId": "sa-cl21-01",
       "attributes": {
         "bpn": [
@@ -2406,6 +2401,7 @@
       "clientRoles": {
         "technical_roles_management": [
           "Semantic Model Management",
+          "Identity Wallet Management",
           "Dataspace Discovery"
         ],
         "Cl3-CX-Semantic": [
@@ -2591,7 +2587,8 @@
         "client": "sa-cl3-cx-1",
         "roles": [
           "Dataspace Discovery",
-          "Semantic Model Management"
+          "Semantic Model Management",
+          "Identity Wallet Management"
         ]
       }
     ],
@@ -3393,10 +3390,6 @@
       "id": "e6ab12bb-3b26-472c-ad0b-3d871bd1461b",
       "clientId": "Cl5-CX-Custodian",
       "name": "Cl5-CX-Custodian",
-      "description": "",
-      "rootUrl": "",
-      "adminUrl": "",
-      "baseUrl": "",
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
@@ -3500,11 +3493,6 @@
     {
       "id": "04cd6d38-674f-4588-980a-8f120bddcc44",
       "clientId": "Cl7-CX-BPDM",
-      "name": "",
-      "description": "",
-      "rootUrl": "",
-      "adminUrl": "",
-      "baseUrl": "",
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
@@ -4296,10 +4284,6 @@
       "id": "7beaee76-d447-4531-9433-fd9ce19d1460",
       "clientId": "sa-cl3-cx-1",
       "name": "Technical User CX internal - communication GitHub and Semantic Hub",
-      "description": "",
-      "rootUrl": "",
-      "adminUrl": "",
-      "baseUrl": "",
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
@@ -4424,11 +4408,7 @@
     {
       "id": "dab9dd17-0d31-46c7-b313-aca61225dcd1",
       "clientId": "sa-cl5-custodian-1",
-      "name": "",
       "description": "Technical User for SD Hub Call to Custodian for SD signature",
-      "rootUrl": "",
-      "adminUrl": "",
-      "baseUrl": "",
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
@@ -5043,6 +5023,21 @@
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "organisation",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "4baa14b7-833e-4bcb-a052-090e65c2bc2c",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
             "jsonType.label": "String"
           }
         },
@@ -5715,18 +5710,7 @@
   ],
   "identityProviderMappers": [
     {
-      "id": "cdbba93b-808f-4101-bd02-f51139ebb107",
-      "name": "username-mapper",
-      "identityProviderAlias": "CX-Operator",
-      "identityProviderMapper": "oidc-username-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "template": "${ALIAS}.${CLAIM.sub}",
-        "target": "LOCAL"
-      }
-    },
-    {
-      "id": "6b19e978-7602-46e3-84fd-9faaa4d28c19",
+      "id": "e01bcaa1-fbfc-4069-a7d7-1dc9844e6696",
       "name": "organisation-mapper",
       "identityProviderAlias": "CX-Operator",
       "identityProviderMapper": "hardcoded-attribute-idp-mapper",
@@ -5734,6 +5718,17 @@
         "attribute.value": "CX-Operator",
         "syncMode": "INHERIT",
         "attribute": "organisation"
+      }
+    },
+    {
+      "id": "b4908715-22a5-4d5a-85c9-aadba0edc548",
+      "name": "username-mapper",
+      "identityProviderAlias": "CX-Operator",
+      "identityProviderMapper": "oidc-username-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "template": "${ALIAS}.${CLAIM.sub}",
+        "target": "LOCAL"
       }
     }
   ],
@@ -5782,14 +5777,14 @@
         "subComponents": {},
         "config": {
           "allowed-protocol-mapper-types": [
-            "saml-user-property-mapper",
-            "oidc-usermodel-attribute-mapper",
-            "oidc-usermodel-property-mapper",
-            "oidc-full-name-mapper",
             "oidc-address-mapper",
             "saml-user-attribute-mapper",
+            "oidc-full-name-mapper",
+            "saml-role-list-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-usermodel-property-mapper",
             "oidc-sha256-pairwise-sub-mapper",
-            "saml-role-list-mapper"
+            "saml-user-property-mapper"
           ]
         }
       },
@@ -5810,13 +5805,13 @@
         "config": {
           "allowed-protocol-mapper-types": [
             "oidc-usermodel-attribute-mapper",
+            "saml-user-attribute-mapper",
+            "saml-role-list-mapper",
             "oidc-address-mapper",
-            "oidc-usermodel-property-mapper",
             "oidc-sha256-pairwise-sub-mapper",
             "oidc-full-name-mapper",
-            "saml-user-attribute-mapper",
-            "saml-user-property-mapper",
-            "saml-role-list-mapper"
+            "oidc-usermodel-property-mapper",
+            "saml-user-property-mapper"
           ]
         }
       },


### PR DESCRIPTION
## Description

- remove view_wallet from Dataspace Discovery
- assign Identity Wallet Management to technical user which previously had Connector User assigned

## Why

assignment of view_wallet to the role "Dataspace Discovery" was wrong

## Issue

https://github.com/eclipse-tractusx/portal-iam/pull/37
CPLP-3556

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
