### PR TITLE
chore(trivy): add skip-dirs for docs

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -59,6 +59,7 @@ jobs:
           format: "sarif"
           output: "trivy-results1.sarif"
           vuln-type: "os,library"
+          skip-dirs: "docs/"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2


### PR DESCRIPTION
## Description

Trivy scan: add skip-dirs for docs

## Why

[docs ](https://github.com/eclipse-tractusx/portal-iam/pull/26) causes false positves,

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
