### PR TITLE
build(2.1.0-RC1): merge release into main

### DIFF
--- a/.github/workflows/cx-iam-consortia.yml
+++ b/.github/workflows/cx-iam-consortia.yml
@@ -61,10 +61,11 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
            # Automatically prepare image tags;
-           # semver patter will generate tags like these for example :v1 :v1.2
+           # semver patter will generate tags like these for example :v1 :v1.2 v1.2.3
           tags: |
             type=raw,value=latest
             type=raw,value=${{ env.REF_NAME }}
+            type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}
             type=semver,pattern=v{{major}}.{{minor}}
 

--- a/.github/workflows/cx-iam.yml
+++ b/.github/workflows/cx-iam.yml
@@ -61,10 +61,11 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
            # Automatically prepare image tags;
-           # semver patter will generate tags like these for example :v1 :v1.2
+           # semver patter will generate tags like these for example :v1 :v1.2 v1.2.3
           tags: |
             type=raw,value=latest
             type=raw,value=${{ env.REF_NAME }}
+            type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}
             type=semver,pattern=v{{major}}.{{minor}}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ New features, fixed bugs, known defects and other noteworthy changes to each rel
 
 ### Bugfix
 
+* fixed upgrade documentation for previous version 2.0.0, pointing to upgrade details for centralidp
 * realm configuration (centralidp) - fixes to CX-Central realm:
   * assigned the following roles from the Cl2-CX-Portal from the composite role "IT Admin":
     * delete_user_account
@@ -56,6 +57,8 @@ The following issues were recently discovered:
 
 * Refresh token rotation causes page reload in frontend apps when using multiple tabs, see [User Token Lifespan](docs/consultation/workshop-20231005.md#user-token-lifespan)
 * Custom login themes break when inserting HTML/CSS/JavaScript code in the IdP display name
+
+Please be aware that **this version is still in Release Candidate phase**: especially documentation is still WIP.
 
 ## 2.0.0
 

--- a/charts/centralidp/Chart.yaml
+++ b/charts/centralidp/Chart.yaml
@@ -20,7 +20,7 @@
 apiVersion: v2
 name: centralidp
 type: application
-version: 2.0.0
+version: 2.1.0-RC1
 appVersion: 22.0.3
 description: Helm chart for Catena-X Central Keycloak Instance
 home: https://github.com/eclipse-tractusx/portal-iam

--- a/charts/centralidp/README.md
+++ b/charts/centralidp/README.md
@@ -1,6 +1,6 @@
 # Helm chart for Catena-X Central Keycloak Instance
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 22.0.3](https://img.shields.io/badge/AppVersion-22.0.3-informational?style=flat-square)
+![Version: 2.1.0-RC1](https://img.shields.io/badge/Version-2.1.0--RC1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 22.0.3](https://img.shields.io/badge/AppVersion-22.0.3-informational?style=flat-square)
 
 This helm chart installs the Helm chart for Catena-X Central Keycloak Instance.
 
@@ -29,7 +29,7 @@ To use the helm chart as a dependency:
 dependencies:
   - name: centralidp
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 2.0.0
+    version: 2.1.0-RC1
 ```
 
 ## Requirements
@@ -59,7 +59,7 @@ dependencies:
 | keycloak.extraVolumeMounts[1].name | string | `"realms"` |  |
 | keycloak.extraVolumeMounts[1].mountPath | string | `"/realms"` |  |
 | keycloak.initContainers[0].name | string | `"import"` |  |
-| keycloak.initContainers[0].image | string | `"tractusx/portal-iam:v2.0.0"` |  |
+| keycloak.initContainers[0].image | string | `"tractusx/portal-iam:v2.1.0-RC1"` |  |
 | keycloak.initContainers[0].imagePullPolicy | string | `"Always"` |  |
 | keycloak.initContainers[0].command[0] | string | `"sh"` |  |
 | keycloak.initContainers[0].args[0] | string | `"-c"` |  |
@@ -105,7 +105,7 @@ dependencies:
 | secrets.postgresql.auth.existingSecret.replicationPassword | string | `""` | Password for the non-root username 'repl_user'. Secret-key 'replication-password'. |
 | seeding.enabled | bool | `false` | Seeding job to upgrade CX_Central realm: enable to upgrade the configuration of the CX-Central realm from previous version; Please also refer to the 'Post-Upgrade Configuration' section in the README.md for configuration possibly not covered by the seeding job |
 | seeding.name | string | `"cx-central-realm-upgrade"` |  |
-| seeding.image | string | `"tractusx/portal-iam-seeding:v2.0.0-iam"` |  |
+| seeding.image | string | `"tractusx/portal-iam-seeding:v2.1.0-iam-RC1"` |  |
 | seeding.portContainer | int | `8080` |  |
 | seeding.authRealm | string | `"master"` |  |
 | seeding.useAuthTrail | string | `"true"` |  |
@@ -119,7 +119,7 @@ dependencies:
 | seeding.extraVolumeMounts[0].name | string | `"realms"` |  |
 | seeding.extraVolumeMounts[0].mountPath | string | `"app/realms"` |  |
 | seeding.initContainers[0].name | string | `"init-cx-central"` |  |
-| seeding.initContainers[0].image | string | `"tractusx/portal-iam:v2.0.0"` |  |
+| seeding.initContainers[0].image | string | `"tractusx/portal-iam:v2.1.0-RC1"` |  |
 | seeding.initContainers[0].imagePullPolicy | string | `"Always"` |  |
 | seeding.initContainers[0].command[0] | string | `"sh"` |  |
 | seeding.initContainers[0].args[0] | string | `"-c"` |  |

--- a/charts/centralidp/README.md
+++ b/charts/centralidp/README.md
@@ -4,7 +4,7 @@
 
 This helm chart installs the Helm chart for Catena-X Central Keycloak Instance.
 
-For further information please refer to the [technical documentation](https://github.com/eclipse-tractusx/portal-assets/tree/v1.6.0/developer/Technical%20Documentation).
+For further information please refer to the [technical documentation](../../docs/technical%20documentation).
 
 The referenced container images are for demonstration purposes only.
 
@@ -156,6 +156,8 @@ We also recommend checking out the [Keycloak Upgrading Guide](https://www.keyclo
 
 To be explicitly mentioned: this major adds the production mode with default value false and the reverse proxy mode with default value passthrough.
 Please check the description of those parameters and decide if they're suitable for you.
+
+Please also refer to [Upgrade Details](../../docs/technical%20documentation/12.%20Upgrade%20Details.md#v200).
 
 #### Upgrade approach
 

--- a/charts/centralidp/README.md.gotmpl
+++ b/charts/centralidp/README.md.gotmpl
@@ -4,7 +4,7 @@
 
 This helm chart installs the {{ template "chart.description" . }}.
 
-For further information please refer to the [technical documentation](https://github.com/eclipse-tractusx/portal-assets/tree/v1.6.0/developer/Technical%20Documentation).
+For further information please refer to the [technical documentation](../../docs/technical%20documentation).
 
 The referenced container images are for demonstration purposes only.
 
@@ -65,6 +65,8 @@ We also recommend checking out the [Keycloak Upgrading Guide](https://www.keyclo
 
 To be explicitly mentioned: this major adds the production mode with default value false and the reverse proxy mode with default value passthrough.
 Please check the description of those parameters and decide if they're suitable for you.
+
+Please also refer to [Upgrade Details](../../docs/technical%20documentation/12.%20Upgrade%20Details.md#v200).
 
 #### Upgrade approach
 

--- a/charts/centralidp/values.yaml
+++ b/charts/centralidp/values.yaml
@@ -48,7 +48,7 @@ keycloak:
       mountPath: "/realms"
   initContainers:
     - name: import
-      image: tractusx/portal-iam:pr44
+      image: tractusx/portal-iam:v2.1.0-RC1
       imagePullPolicy: Always
       command:
         - sh
@@ -150,7 +150,7 @@ seeding:
 # for configuration possibly not covered by the seeding job
   enabled: false
   name: "cx-central-realm-upgrade"
-  image: "tractusx/portal-iam-seeding:v2.0.0-iam"
+  image: "tractusx/portal-iam-seeding:v2.1.0-iam-RC1"
   portContainer: 8080
   authRealm: "master"
   useAuthTrail: "true"
@@ -178,7 +178,7 @@ seeding:
       mountPath: "app/realms"
   initContainers:
     - name: init-cx-central
-      image: tractusx/portal-iam:pr44
+      image: tractusx/portal-iam:v2.1.0-RC1
       imagePullPolicy: Always
       command:
         - sh

--- a/charts/sharedidp/Chart.yaml
+++ b/charts/sharedidp/Chart.yaml
@@ -20,7 +20,7 @@
 apiVersion: v2
 name: sharedidp
 type: application
-version: 2.0.0
+version: 2.1.0-RC1
 appVersion: 22.0.3
 description: Helm chart for Catena-X Shared Keycloak Instance
 home: https://github.com/eclipse-tractusx/portal-iam

--- a/charts/sharedidp/README.md
+++ b/charts/sharedidp/README.md
@@ -4,7 +4,7 @@
 
 This helm chart installs the Helm chart for Catena-X Shared Keycloak Instance.
 
-For further information please refer to the [technical documentation](https://github.com/eclipse-tractusx/portal-assets/tree/v1.6.0/developer/Technical%20Documentation).
+For further information please refer to the [technical documentation](../../docs/technical%20documentation).
 
 The referenced container images are for demonstration purposes only.
 

--- a/charts/sharedidp/README.md
+++ b/charts/sharedidp/README.md
@@ -1,6 +1,6 @@
 # Helm chart for Catena-X Shared Keycloak Instance
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 22.0.3](https://img.shields.io/badge/AppVersion-22.0.3-informational?style=flat-square)
+![Version: 2.1.0-RC1](https://img.shields.io/badge/Version-2.1.0--RC1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 22.0.3](https://img.shields.io/badge/AppVersion-22.0.3-informational?style=flat-square)
 
 This helm chart installs the Helm chart for Catena-X Shared Keycloak Instance.
 
@@ -29,7 +29,7 @@ To use the helm chart as a dependency:
 dependencies:
   - name: sharedidp
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 2.0.0
+    version: 2.1.0-RC1
 ```
 
 ## Requirements
@@ -63,7 +63,7 @@ dependencies:
 | keycloak.extraVolumeMounts[2].name | string | `"realms"` |  |
 | keycloak.extraVolumeMounts[2].mountPath | string | `"/realms"` |  |
 | keycloak.initContainers[0].name | string | `"import"` |  |
-| keycloak.initContainers[0].image | string | `"tractusx/portal-iam:v2.0.0"` |  |
+| keycloak.initContainers[0].image | string | `"tractusx/portal-iam:v2.1.0-RC1"` |  |
 | keycloak.initContainers[0].imagePullPolicy | string | `"Always"` |  |
 | keycloak.initContainers[0].command[0] | string | `"sh"` |  |
 | keycloak.initContainers[0].args[0] | string | `"-c"` |  |

--- a/charts/sharedidp/README.md.gotmpl
+++ b/charts/sharedidp/README.md.gotmpl
@@ -4,7 +4,7 @@
 
 This helm chart installs the {{ template "chart.description" . }}.
 
-For further information please refer to the [technical documentation](https://github.com/eclipse-tractusx/portal-assets/tree/v1.6.0/developer/Technical%20Documentation).
+For further information please refer to the [technical documentation](../../docs/technical%20documentation).
 
 The referenced container images are for demonstration purposes only.
 

--- a/charts/sharedidp/values.yaml
+++ b/charts/sharedidp/values.yaml
@@ -52,7 +52,7 @@ keycloak:
       mountPath: "/realms"
   initContainers:
     - name: import
-      image: tractusx/portal-iam:pr44
+      image: tractusx/portal-iam:v2.1.0-RC1
       imagePullPolicy: Always
       command:
         - sh

--- a/consortia/argocd-app-templates/centralidp/appsetup-beta.yaml
+++ b/consortia/argocd-app-templates/centralidp/appsetup-beta.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/centralidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: v2.0.0
+    targetRevision: v2.1.0-RC1
     plugin:
       env:
         - name: AVP_SECRET

--- a/consortia/argocd-app-templates/centralidp/appsetup-int.yaml
+++ b/consortia/argocd-app-templates/centralidp/appsetup-int.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/centralidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: v2.0.0
+    targetRevision: v2.1.0-RC1
     plugin:
       env:
         - name: AVP_SECRET

--- a/consortia/argocd-app-templates/centralidp/appsetup-pen.yaml
+++ b/consortia/argocd-app-templates/centralidp/appsetup-pen.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/centralidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: v2.0.0
+    targetRevision: v2.1.0-RC1
     plugin:
       env:
         - name: AVP_SECRET

--- a/consortia/argocd-app-templates/centralidp/appsetup-rc.yaml
+++ b/consortia/argocd-app-templates/centralidp/appsetup-rc.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/centralidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: v2.0.0
+    targetRevision: v2.1.0-RC1
     plugin:
       env:
         - name: AVP_SECRET

--- a/consortia/argocd-app-templates/centralidp/appsetup-stable.yaml
+++ b/consortia/argocd-app-templates/centralidp/appsetup-stable.yaml
@@ -29,7 +29,7 @@ spec:
   source:
     path: ''
     repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
-    targetRevision: 2.0.0
+    targetRevision: 2.1.0-RC1
     plugin:
       env:
         - name: HELM_VALUES
@@ -37,7 +37,7 @@ spec:
             keycloak:
               initContainers:
                 - name: import
-                  image: tractusx/portal-iam-consortia:v2.0.0
+                  image: tractusx/portal-iam-consortia:v2.1.0-RC1
                   imagePullPolicy: Always
                   command:
                     - sh
@@ -83,7 +83,7 @@ spec:
               enabled: true
               initContainers:
                 - name: init-cx-central
-                  image: tractusx/portal-iam-consortia:v2.0.0
+                  image: tractusx/portal-iam-consortia:v2.1.0-RC1
                   imagePullPolicy: Always
                   command:
                     - sh

--- a/consortia/argocd-app-templates/centralidp/appsetup-templateconsortia.yaml
+++ b/consortia/argocd-app-templates/centralidp/appsetup-templateconsortia.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/centralidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: v2.0.0
+    targetRevision: v2.1.0-RC1
     plugin:
       env:
         - name: AVP_SECRET

--- a/consortia/argocd-app-templates/centralidp/appsetup-templategeneric.yaml
+++ b/consortia/argocd-app-templates/centralidp/appsetup-templategeneric.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/centralidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: v2.0.0
+    targetRevision: v2.1.0-RC1
     plugin:
       env:
         - name: AVP_SECRET

--- a/consortia/argocd-app-templates/centralidp/appsetup-upgrade.yaml
+++ b/consortia/argocd-app-templates/centralidp/appsetup-upgrade.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/centralidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: v2.0.0
+    targetRevision: v2.1.0-RC1
     plugin:
       env:
         - name: AVP_SECRET

--- a/consortia/argocd-app-templates/sharedidp/appsetup-beta.yaml
+++ b/consortia/argocd-app-templates/sharedidp/appsetup-beta.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/sharedidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: v2.0.0
+    targetRevision: v2.1.0-RC1
     plugin:
       env:
         - name: AVP_SECRET

--- a/consortia/argocd-app-templates/sharedidp/appsetup-int.yaml
+++ b/consortia/argocd-app-templates/sharedidp/appsetup-int.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/sharedidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: v2.0.0
+    targetRevision: v2.1.0-RC1
     plugin:
       env:
         - name: AVP_SECRET

--- a/consortia/argocd-app-templates/sharedidp/appsetup-pen.yaml
+++ b/consortia/argocd-app-templates/sharedidp/appsetup-pen.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/sharedidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: v2.0.0
+    targetRevision: v2.1.0-RC1
     plugin:
       env:
         - name: AVP_SECRET

--- a/consortia/argocd-app-templates/sharedidp/appsetup-rc.yaml
+++ b/consortia/argocd-app-templates/sharedidp/appsetup-rc.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/sharedidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: v2.0.0
+    targetRevision: v2.1.0-RC1
     plugin:
       env:
         - name: AVP_SECRET

--- a/consortia/argocd-app-templates/sharedidp/appsetup-stable.yaml
+++ b/consortia/argocd-app-templates/sharedidp/appsetup-stable.yaml
@@ -29,7 +29,7 @@ spec:
   source:
     path: ''
     repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
-    targetRevision: 2.0.0
+    targetRevision: 2.1.0-RC1
     plugin:
       env:
         - name: HELM_VALUES
@@ -56,7 +56,7 @@ spec:
                   mountPath: "/secrets"
               initContainers:
                 - name: import
-                  image: tractusx/portal-iam-consortia:v2.0.0
+                  image: tractusx/portal-iam-consortia:v2.1.0-RC1
                   imagePullPolicy: Always
                   command:
                     - sh

--- a/consortia/argocd-app-templates/sharedidp/appsetup-templateconsortia.yaml
+++ b/consortia/argocd-app-templates/sharedidp/appsetup-templateconsortia.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/sharedidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: v2.0.0
+    targetRevision: v2.1.0-RC1
     plugin:
       env:
         - name: AVP_SECRET

--- a/consortia/argocd-app-templates/sharedidp/appsetup-templategeneric.yaml
+++ b/consortia/argocd-app-templates/sharedidp/appsetup-templategeneric.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/sharedidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: v2.0.0
+    targetRevision: v2.1.0-RC1
     plugin:
       env:
         - name: AVP_SECRET

--- a/consortia/argocd-app-templates/sharedidp/appsetup-upgrade.yaml
+++ b/consortia/argocd-app-templates/sharedidp/appsetup-upgrade.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/sharedidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: v2.0.0
+    targetRevision: v2.1.0-RC1
     plugin:
       env:
         - name: AVP_SECRET

--- a/consortia/environments/centralidp/values-beta.yaml
+++ b/consortia/environments/centralidp/values-beta.yaml
@@ -22,7 +22,7 @@ keycloak:
   proxy: edge
   initContainers:
     - name: import
-      image: tractusx/portal-iam-consortia:pr44
+      image: tractusx/portal-iam-consortia:v2.1.0-RC1
       imagePullPolicy: Always
       command:
         - sh
@@ -69,7 +69,7 @@ seeding:
   enabled: true
   initContainers:
     - name: init-cx-central
-      image: tractusx/portal-iam-consortia:pr44
+      image: tractusx/portal-iam-consortia:v2.1.0-RC1
       imagePullPolicy: Always
       command:
         - sh

--- a/consortia/environments/centralidp/values-int.yaml
+++ b/consortia/environments/centralidp/values-int.yaml
@@ -22,7 +22,7 @@ keycloak:
   proxy: edge
   initContainers:
     - name: import
-      image: tractusx/portal-iam-consortia:pr44
+      image: tractusx/portal-iam-consortia:v2.1.0-RC1
       imagePullPolicy: Always
       command:
         - sh
@@ -69,7 +69,7 @@ seeding:
   enabled: false
   initContainers:
     - name: init-cx-central
-      image: tractusx/portal-iam-consortia:pr44
+      image: tractusx/portal-iam-consortia:v2.1.0-RC1
       imagePullPolicy: Always
       command:
         - sh

--- a/consortia/environments/centralidp/values-pen.yaml
+++ b/consortia/environments/centralidp/values-pen.yaml
@@ -22,7 +22,7 @@ keycloak:
   proxy: edge
   initContainers:
     - name: import
-      image: tractusx/portal-iam-consortia:pr44
+      image: tractusx/portal-iam-consortia:v2.1.0-RC1
       imagePullPolicy: Always
       command:
         - sh
@@ -69,7 +69,7 @@ seeding:
   enabled: true
   initContainers:
     - name: init-cx-central
-      image: tractusx/portal-iam-consortia:pr44
+      image: tractusx/portal-iam-consortia:v2.1.0-RC1
       imagePullPolicy: Always
       command:
         - sh

--- a/consortia/environments/centralidp/values-rc.yaml
+++ b/consortia/environments/centralidp/values-rc.yaml
@@ -22,7 +22,7 @@ keycloak:
   proxy: edge
   initContainers:
     - name: import
-      image: tractusx/portal-iam-consortia:pr44
+      image: tractusx/portal-iam-consortia:v2.1.0-RC1
       imagePullPolicy: Always
       command:
         - sh
@@ -69,7 +69,7 @@ seeding:
   enabled: true
   initContainers:
     - name: init-cx-central
-      image: tractusx/portal-iam-consortia:pr44
+      image: tractusx/portal-iam-consortia:v2.1.0-RC1
       imagePullPolicy: Always
       command:
         - sh

--- a/consortia/environments/centralidp/values-templateconsortia.yaml
+++ b/consortia/environments/centralidp/values-templateconsortia.yaml
@@ -22,7 +22,7 @@ keycloak:
   proxy: edge
   initContainers:
     - name: import
-      image: tractusx/portal-iam-consortia:pr44
+      image: tractusx/portal-iam-consortia:v2.1.0-RC1
       imagePullPolicy: Always
       command:
         - sh
@@ -67,10 +67,10 @@ secrets:
 
 seeding:
   enabled: false
-  image: "tractusx/portal-iam-seeding:dev"
+  image: "tractusx/portal-iam-seeding:v2.1.0-iam-RC1"
   initContainers:
     - name: init-cx-central
-      image: tractusx/portal-iam-consortia:pr44
+      image: tractusx/portal-iam-consortia:v2.1.0-RC1
       imagePullPolicy: Always
       command:
         - sh

--- a/consortia/environments/centralidp/values-templategeneric.yaml
+++ b/consortia/environments/centralidp/values-templategeneric.yaml
@@ -22,7 +22,7 @@ keycloak:
   proxy: edge
   initContainers:
     - name: import
-      image: tractusx/portal-iam:pr44
+      image: tractusx/portal-iam:v2.1.0-RC1
       imagePullPolicy: Always
       command:
         - sh
@@ -67,10 +67,10 @@ secrets:
 
 seeding:
   enabled: true
-  image: "tractusx/portal-iam-seeding:rc"
+  image: "tractusx/portal-iam-seeding:v2.1.0-iam-RC1"
   initContainers:
     - name: init-cx-central
-      image: tractusx/portal-iam:pr44
+      image: tractusx/portal-iam:v2.1.0-RC1
       imagePullPolicy: Always
       command:
         - sh

--- a/consortia/environments/sharedidp/values-beta.yaml
+++ b/consortia/environments/sharedidp/values-beta.yaml
@@ -41,7 +41,7 @@ keycloak:
       mountPath: "/secrets"
   initContainers:
     - name: import
-      image: tractusx/portal-iam-consortia:pr44
+      image: tractusx/portal-iam-consortia:v2.1.0-RC1
       imagePullPolicy: Always
       command:
         - sh

--- a/consortia/environments/sharedidp/values-int.yaml
+++ b/consortia/environments/sharedidp/values-int.yaml
@@ -41,7 +41,7 @@ keycloak:
       mountPath: "/secrets"
   initContainers:
     - name: import
-      image: tractusx/portal-iam-consortia:pr44
+      image: tractusx/portal-iam-consortia:v2.1.0-RC1
       imagePullPolicy: Always
       command:
         - sh

--- a/consortia/environments/sharedidp/values-pen.yaml
+++ b/consortia/environments/sharedidp/values-pen.yaml
@@ -41,7 +41,7 @@ keycloak:
       mountPath: "/secrets"
   initContainers:
     - name: import
-      image: tractusx/portal-iam-consortia:pr44
+      image: tractusx/portal-iam-consortia:v2.1.0-RC1
       imagePullPolicy: Always
       command:
         - sh

--- a/consortia/environments/sharedidp/values-rc.yaml
+++ b/consortia/environments/sharedidp/values-rc.yaml
@@ -41,7 +41,7 @@ keycloak:
       mountPath: "/secrets"
   initContainers:
     - name: import
-      image: tractusx/portal-iam-consortia:pr44
+      image: tractusx/portal-iam-consortia:v2.1.0-RC1
       imagePullPolicy: Always
       command:
         - sh

--- a/consortia/environments/sharedidp/values-templateconsortia.yaml
+++ b/consortia/environments/sharedidp/values-templateconsortia.yaml
@@ -41,7 +41,7 @@ keycloak:
       mountPath: "/secrets"
   initContainers:
     - name: import
-      image: tractusx/portal-iam-consortia:pr44
+      image: tractusx/portal-iam-consortia:v2.1.0-RC1
       imagePullPolicy: Always
       command:
         - sh

--- a/consortia/environments/sharedidp/values-templategeneric.yaml
+++ b/consortia/environments/sharedidp/values-templategeneric.yaml
@@ -36,7 +36,7 @@ keycloak:
       mountPath: "/realms"
   initContainers:
     - name: import
-      image: tractusx/portal-iam:pr44
+      image: tractusx/portal-iam:v2.1.0-RC1
       imagePullPolicy: Always
       command:
         - sh

--- a/docs/technical documentation/12. Upgrade Details.md
+++ b/docs/technical documentation/12. Upgrade Details.md
@@ -1,5 +1,5 @@
 - [Summary](#summary)
-  - [v1.7.0](#v170)
+  - [v2.0.0](#v200)
     - [Role Concept changes - UPDATE](#role-concept-changes---update)
 - [NOTICE](#notice)
 
@@ -8,7 +8,7 @@
 This document describes the Keycloak database changes and its impact on transactional data. Depending on the impact, possible risks/impediments on upgrades as well as mitigation plans are described.
 Each section includes the respective change details, impact on existing data and the respective release with which the change is getting active.
 
-### v1.7.0
+### v2.0.0
 
 #### Role Concept changes - UPDATE
 


### PR DESCRIPTION
## Description

Bump chart version
Update CHANGELOG
Update README

- fixed upgrade documentation for previous version 2.0.0, pointing to upgrade details for centralidp
- added additional image tag of type semver for init container build

## Why

Merge the latest changes to main

## Issue

N/A

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
