### PR TITLE
chore(trg-2.04): change portal-cd references to portal

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -23,12 +23,12 @@ SPDX-License-Identifier: Apache-2.0
 The project maintains the following source code repositories in the GitHub organization https://github.com/eclipse-tractusx:
 
 - https://github.com/eclipse-tractusx/portal-iam
-- https://github.com/eclipse-tractusx/portal-frontend-registration
+- https://github.com/eclipse-tractusx/portal
 - https://github.com/eclipse-tractusx/portal-frontend
+- https://github.com/eclipse-tractusx/portal-frontend-registration
 - https://github.com/eclipse-tractusx/portal-shared-components
 - https://github.com/eclipse-tractusx/portal-backend
 - https://github.com/eclipse-tractusx/portal-assets
-- https://github.com/eclipse-tractusx/portal-cd
 
 ## Third-party Content
 


### PR DESCRIPTION
## Description

change portal-cd references to portal

## Why

TRG-2.04 compliance

## Issue

https://github.com/eclipse-tractusx/portal-cd/issues/131

## Checklist

- [x] I have performed a self-review of my changes