### PR TITLE
feat: upgrade to keycloak v23.0.7

### DIFF
--- a/.github/workflows/centralidp-chart-test.yaml
+++ b/.github/workflows/centralidp-chart-test.yaml
@@ -32,13 +32,13 @@ on:
       node_image:
         description: 'kindest/node image for k8s kind cluster'
         # k8s version to support
-        default: 'kindest/node:v1.26.6'
+        default: 'kindest/node:v1.27.3'
         required: false
         type: string
       upgrade_from:
         description: 'portal chart version to upgrade from'
-        # centralidp version from 23.09 release
-        default: '1.2.0'
+        # centralidp version from 24.03 release
+        default: '2.1.0'
         required: false
         type: string
 
@@ -55,7 +55,7 @@ jobs:
         uses: container-tools/kind-action@v2
         with:
           version: v0.19.0
-          node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.26.6' }}
+          node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.27.3' }}
 
       - name: Set up Helm
         uses: azure/setup-helm@v3
@@ -93,7 +93,7 @@ jobs:
         run: |
           helm repo add bitnami-full-index https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
           helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
-          helm install centralidp tractusx-dev/centralidp --version ${{ github.event.inputs.upgrade_from || '1.2.0' }}
+          helm install centralidp tractusx-dev/centralidp --version ${{ github.event.inputs.upgrade_from || '2.1.0' }}
           helm dependency update charts/centralidp
           helm upgrade centralidp charts/centralidp
         if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/sharedidp-chart-test.yaml
+++ b/.github/workflows/sharedidp-chart-test.yaml
@@ -32,13 +32,13 @@ on:
       node_image:
         description: 'kindest/node image for k8s kind cluster'
         # k8s version to support
-        default: 'kindest/node:v1.26.6'
+        default: 'kindest/node:v1.27.3'
         required: false
         type: string
       upgrade_from:
         description: 'portal chart version to upgrade from'
-        # sharedidp version from 23.09 release
-        default: '1.2.0'
+        # sharedidp version from 24.03 release
+        default: '2.1.0'
         required: false
         type: string
 
@@ -55,7 +55,7 @@ jobs:
         uses: container-tools/kind-action@v2
         with:
           version: v0.19.0
-          node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.26.6' }}
+          node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.27.3' }}
 
       - name: Set up Helm
         uses: azure/setup-helm@v3
@@ -93,7 +93,7 @@ jobs:
         run: |
           helm repo add bitnami-full-index https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
           helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
-          helm install sharedidp tractusx-dev/sharedidp --version ${{ github.event.inputs.upgrade_from || '1.2.0' }}
+          helm install sharedidp tractusx-dev/sharedidp --version ${{ github.event.inputs.upgrade_from || '2.1.0' }}
           helm dependency update charts/sharedidp
           helm upgrade sharedidp charts/sharedidp
         if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repository contains the reference configuration to deploy the Catena-X (CX) specific Keycloak instances.
 
-The instances depend on the [helm chart from Bitnami](https://artifacthub.io/packages/helm/bitnami/keycloak) (chart version 16.1.6, app version 22.0.3).
+The instances depend on the [helm chart from Bitnami](https://artifacthub.io/packages/helm/bitnami/keycloak) (chart version 19.3.0, app version 23.0.7).
 
 The repository is split up in:
 

--- a/charts/centralidp/Chart.yaml
+++ b/charts/centralidp/Chart.yaml
@@ -20,8 +20,8 @@
 apiVersion: v2
 name: centralidp
 type: application
-version: 2.1.0
-appVersion: 22.0.3
+version: 3.0.0-rc.1
+appVersion: 23.0.7
 description: Helm chart for Catena-X Central Keycloak Instance
 home: https://github.com/eclipse-tractusx/portal-iam
 sources:
@@ -29,4 +29,4 @@ sources:
 dependencies:
   - name: keycloak
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
-    version: 16.1.6
+    version: 19.3.0

--- a/charts/centralidp/Chart.yaml
+++ b/charts/centralidp/Chart.yaml
@@ -22,7 +22,7 @@ name: centralidp
 type: application
 version: 3.0.0-rc.1
 appVersion: 23.0.7
-description: Helm chart for Catena-X Central Keycloak Instance
+description: Helm chart for Central Keycloak Instance
 home: https://github.com/eclipse-tractusx/portal-iam
 sources:
   - https://github.com/eclipse-tractusx/portal-iam

--- a/charts/centralidp/README.md.gotmpl
+++ b/charts/centralidp/README.md.gotmpl
@@ -55,13 +55,19 @@ This is done by setting the 'example.org' placeholder in the CX-Operator' Identi
 
 Please see notes at [Values.seeding](values.yaml#L146) for upgrading the configuration of the CX-Central realm.
 
+### To 3.0.0
+
+This major changes from the Keycloak version from  22.0.3 to 23.0.7 and bumps the PostgresSQL version of the subchart from 15.4.0 to 15.6.0.
+
+No major issues are expected during the upgrade.
+
 ### To 2.1.0
 
 No specific upgrade notes.
 
 ### To 2.0.0
 
-This major changes from Keycloak version 16.1.1 to version 22.0.3.
+This major changes from the Keycloak version from 16.1.1 to version 22.0.3.
 
 Please have a look at the [CHANGELOG](../../CHANGELOG.md#200) for a more detailed description.
 

--- a/charts/centralidp/values.yaml
+++ b/charts/centralidp/values.yaml
@@ -48,7 +48,7 @@ keycloak:
       mountPath: "/realms"
   initContainers:
     - name: import
-      image: docker.io/tractusx/portal-iam:v2.1.0
+      image: docker.io/tractusx/portal-iam:pr63
       imagePullPolicy: Always
       command:
         - sh
@@ -182,7 +182,7 @@ seeding:
       mountPath: "app/realms"
   initContainers:
     - name: init-cx-central
-      image: docker.io/tractusx/portal-iam:v2.1.0
+      image: docker.io/tractusx/portal-iam:pr63
       imagePullPolicy: IfNotPresent
       command:
         - sh

--- a/charts/centralidp/values.yaml
+++ b/charts/centralidp/values.yaml
@@ -102,6 +102,11 @@ keycloak:
   # port: 5432;
     # Switch to enable or disable the PostgreSQL helm chart.
     enabled: true
+    # -- Setting to Postgres version 15 as that is the aligned version,
+    # https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-07/#aligning-dependency-versions).
+    # Keycloak helm-chart from Bitnami has moved on to version 16.
+    image:
+      tag: "15.6.0"
     auth:
       # -- Non-root username.
       username: kccentral

--- a/charts/sharedidp/Chart.yaml
+++ b/charts/sharedidp/Chart.yaml
@@ -22,7 +22,7 @@ name: sharedidp
 type: application
 version: 3.0.0-rc.1
 appVersion: 23.0.7
-description: Helm chart for Catena-X Shared Keycloak Instance
+description: Helm chart for Shared Keycloak Instance
 home: https://github.com/eclipse-tractusx/portal-iam
 sources:
   - https://github.com/eclipse-tractusx/portal-iam

--- a/charts/sharedidp/Chart.yaml
+++ b/charts/sharedidp/Chart.yaml
@@ -20,8 +20,8 @@
 apiVersion: v2
 name: sharedidp
 type: application
-version: 2.1.0
-appVersion: 22.0.3
+version: 3.0.0-rc.1
+appVersion: 23.0.7
 description: Helm chart for Catena-X Shared Keycloak Instance
 home: https://github.com/eclipse-tractusx/portal-iam
 sources:
@@ -29,4 +29,4 @@ sources:
 dependencies:
   - name: keycloak
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
-    version: 16.1.6
+    version: 19.3.0

--- a/charts/sharedidp/README.md.gotmpl
+++ b/charts/sharedidp/README.md.gotmpl
@@ -61,13 +61,19 @@ Generate client-secrets for the service account with access type 'confidential'.
 
 ## Upgrade
 
+### To 3.0.0
+
+This major changes from the Keycloak version from  22.0.3 to 23.0.7 and bumps the PostgresSQL version of the subchart from 15.4.0 to 15.6.0.
+
+No major issues are expected during the upgrade.
+
 ### To 2.1.0
 
 No specific upgrade notes.
 
 ### To 2.0.0
 
-This major changes from Keycloak version 16.1.1 to version 22.0.3.
+This major changes from the Keycloak version from 16.1.1 to version 22.0.3.
 
 Please have a look at the [CHANGELOG](../../CHANGELOG.md#200) for a more detailed description.
 

--- a/charts/sharedidp/values.yaml
+++ b/charts/sharedidp/values.yaml
@@ -52,7 +52,7 @@ keycloak:
       mountPath: "/realms"
   initContainers:
     - name: import
-      image: docker.io/tractusx/portal-iam:v2.1.0
+      image: docker.io/tractusx/portal-iam:pr63
       imagePullPolicy: Always
       command:
         - sh

--- a/charts/sharedidp/values.yaml
+++ b/charts/sharedidp/values.yaml
@@ -110,6 +110,11 @@ keycloak:
   # port: 5432;
     # Switch to enable or disable the PostgreSQL helm chart.
     enabled: true
+    # -- Setting to Postgres version 15 as that is the aligned version,
+    # https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-07/#aligning-dependency-versions).
+    # Keycloak helm-chart from Bitnami has moved on to version 16.
+    image:
+      tag: "15.6.0"
     auth:
       # -- Non-root username.
       username: kcshared

--- a/import/realm-config/consortia/catenax-central/beta/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/beta/CX-Central-realm.json
@@ -17413,7 +17413,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-central/dev/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/dev/CX-Central-realm.json
@@ -17413,7 +17413,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-central/int/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/int/CX-Central-realm.json
@@ -17413,7 +17413,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-central/pen/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/pen/CX-Central-realm.json
@@ -17413,7 +17413,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-central/rc/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/rc/CX-Central-realm.json
@@ -17413,7 +17413,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-central/stable/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/stable/CX-Central-realm.json
@@ -17413,7 +17413,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/beta/App-Provider-realm.json
+++ b/import/realm-config/consortia/catenax-shared/beta/App-Provider-realm.json
@@ -2137,7 +2137,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/beta/CX-Operator-realm.json
+++ b/import/realm-config/consortia/catenax-shared/beta/CX-Operator-realm.json
@@ -2127,7 +2127,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/beta/CX-Test-Access-realm.json
+++ b/import/realm-config/consortia/catenax-shared/beta/CX-Test-Access-realm.json
@@ -2288,7 +2288,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/beta/Company-1-realm.json
+++ b/import/realm-config/consortia/catenax-shared/beta/Company-1-realm.json
@@ -2170,7 +2170,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/beta/Company-2-realm.json
+++ b/import/realm-config/consortia/catenax-shared/beta/Company-2-realm.json
@@ -2161,7 +2161,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/beta/Onboarding-Provider-realm.json
+++ b/import/realm-config/consortia/catenax-shared/beta/Onboarding-Provider-realm.json
@@ -2162,7 +2162,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/beta/Security-Company-realm.json
+++ b/import/realm-config/consortia/catenax-shared/beta/Security-Company-realm.json
@@ -2160,7 +2160,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/beta/Service-Provider-realm.json
+++ b/import/realm-config/consortia/catenax-shared/beta/Service-Provider-realm.json
@@ -2137,7 +2137,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/beta/master-realm.json
+++ b/import/realm-config/consortia/catenax-shared/beta/master-realm.json
@@ -5209,7 +5209,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/dev/App-Provider-realm.json
+++ b/import/realm-config/consortia/catenax-shared/dev/App-Provider-realm.json
@@ -2137,7 +2137,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/dev/CX-Operator-realm.json
+++ b/import/realm-config/consortia/catenax-shared/dev/CX-Operator-realm.json
@@ -2127,7 +2127,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/dev/CX-Test-Access-realm.json
+++ b/import/realm-config/consortia/catenax-shared/dev/CX-Test-Access-realm.json
@@ -2288,7 +2288,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/dev/Company-1-realm.json
+++ b/import/realm-config/consortia/catenax-shared/dev/Company-1-realm.json
@@ -2170,7 +2170,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/dev/Company-2-realm.json
+++ b/import/realm-config/consortia/catenax-shared/dev/Company-2-realm.json
@@ -2161,7 +2161,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/dev/Onboarding-Provider-realm.json
+++ b/import/realm-config/consortia/catenax-shared/dev/Onboarding-Provider-realm.json
@@ -2162,7 +2162,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/dev/Security-Company-realm.json
+++ b/import/realm-config/consortia/catenax-shared/dev/Security-Company-realm.json
@@ -2160,7 +2160,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/dev/Service-Provider-realm.json
+++ b/import/realm-config/consortia/catenax-shared/dev/Service-Provider-realm.json
@@ -2137,7 +2137,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/dev/master-realm.json
+++ b/import/realm-config/consortia/catenax-shared/dev/master-realm.json
@@ -5209,7 +5209,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/int/App-Provider-realm.json
+++ b/import/realm-config/consortia/catenax-shared/int/App-Provider-realm.json
@@ -2137,7 +2137,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/int/CX-Operator-realm.json
+++ b/import/realm-config/consortia/catenax-shared/int/CX-Operator-realm.json
@@ -2127,7 +2127,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/int/CX-Test-Access-realm.json
+++ b/import/realm-config/consortia/catenax-shared/int/CX-Test-Access-realm.json
@@ -2288,7 +2288,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/int/Company-1-realm.json
+++ b/import/realm-config/consortia/catenax-shared/int/Company-1-realm.json
@@ -2170,7 +2170,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/int/Company-2-realm.json
+++ b/import/realm-config/consortia/catenax-shared/int/Company-2-realm.json
@@ -2161,7 +2161,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/int/Onboarding-Provider-realm.json
+++ b/import/realm-config/consortia/catenax-shared/int/Onboarding-Provider-realm.json
@@ -2162,7 +2162,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/int/Security-Company-realm.json
+++ b/import/realm-config/consortia/catenax-shared/int/Security-Company-realm.json
@@ -2160,7 +2160,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/int/Service-Provider-realm.json
+++ b/import/realm-config/consortia/catenax-shared/int/Service-Provider-realm.json
@@ -2137,7 +2137,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/int/master-realm.json
+++ b/import/realm-config/consortia/catenax-shared/int/master-realm.json
@@ -5209,7 +5209,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/pen/App-Provider-realm.json
+++ b/import/realm-config/consortia/catenax-shared/pen/App-Provider-realm.json
@@ -2137,7 +2137,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/pen/CX-Operator-realm.json
+++ b/import/realm-config/consortia/catenax-shared/pen/CX-Operator-realm.json
@@ -2127,7 +2127,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/pen/CX-Test-Access-realm.json
+++ b/import/realm-config/consortia/catenax-shared/pen/CX-Test-Access-realm.json
@@ -2288,7 +2288,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/pen/Company-1-realm.json
+++ b/import/realm-config/consortia/catenax-shared/pen/Company-1-realm.json
@@ -2170,7 +2170,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/pen/Company-2-realm.json
+++ b/import/realm-config/consortia/catenax-shared/pen/Company-2-realm.json
@@ -2161,7 +2161,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/pen/Onboarding-Provider-realm.json
+++ b/import/realm-config/consortia/catenax-shared/pen/Onboarding-Provider-realm.json
@@ -2162,7 +2162,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/pen/Security-Company-realm.json
+++ b/import/realm-config/consortia/catenax-shared/pen/Security-Company-realm.json
@@ -2160,7 +2160,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/pen/Service-Provider-realm.json
+++ b/import/realm-config/consortia/catenax-shared/pen/Service-Provider-realm.json
@@ -2137,7 +2137,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/pen/master-realm.json
+++ b/import/realm-config/consortia/catenax-shared/pen/master-realm.json
@@ -5209,7 +5209,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/rc/App-Provider-realm.json
+++ b/import/realm-config/consortia/catenax-shared/rc/App-Provider-realm.json
@@ -2137,7 +2137,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/rc/CX-Operator-realm.json
+++ b/import/realm-config/consortia/catenax-shared/rc/CX-Operator-realm.json
@@ -2127,7 +2127,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/rc/CX-Test-Access-realm.json
+++ b/import/realm-config/consortia/catenax-shared/rc/CX-Test-Access-realm.json
@@ -2288,7 +2288,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/rc/Company-1-realm.json
+++ b/import/realm-config/consortia/catenax-shared/rc/Company-1-realm.json
@@ -2170,7 +2170,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/rc/Company-2-realm.json
+++ b/import/realm-config/consortia/catenax-shared/rc/Company-2-realm.json
@@ -2161,7 +2161,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/rc/Onboarding-Provider-realm.json
+++ b/import/realm-config/consortia/catenax-shared/rc/Onboarding-Provider-realm.json
@@ -2162,7 +2162,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/rc/Security-Company-realm.json
+++ b/import/realm-config/consortia/catenax-shared/rc/Security-Company-realm.json
@@ -2160,7 +2160,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/rc/Service-Provider-realm.json
+++ b/import/realm-config/consortia/catenax-shared/rc/Service-Provider-realm.json
@@ -2137,7 +2137,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/rc/master-realm.json
+++ b/import/realm-config/consortia/catenax-shared/rc/master-realm.json
@@ -5209,7 +5209,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/stable/App-Provider-realm.json
+++ b/import/realm-config/consortia/catenax-shared/stable/App-Provider-realm.json
@@ -2137,7 +2137,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/stable/CX-Operator-realm.json
+++ b/import/realm-config/consortia/catenax-shared/stable/CX-Operator-realm.json
@@ -2127,7 +2127,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/stable/CX-Test-Access-realm.json
+++ b/import/realm-config/consortia/catenax-shared/stable/CX-Test-Access-realm.json
@@ -2288,7 +2288,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/stable/Company-1-realm.json
+++ b/import/realm-config/consortia/catenax-shared/stable/Company-1-realm.json
@@ -2170,7 +2170,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/stable/Company-2-realm.json
+++ b/import/realm-config/consortia/catenax-shared/stable/Company-2-realm.json
@@ -2161,7 +2161,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/stable/Onboarding-Provider-realm.json
+++ b/import/realm-config/consortia/catenax-shared/stable/Onboarding-Provider-realm.json
@@ -2162,7 +2162,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/stable/Security-Company-realm.json
+++ b/import/realm-config/consortia/catenax-shared/stable/Security-Company-realm.json
@@ -2160,7 +2160,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/stable/Service-Provider-realm.json
+++ b/import/realm-config/consortia/catenax-shared/stable/Service-Provider-realm.json
@@ -2137,7 +2137,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/consortia/catenax-shared/stable/master-realm.json
+++ b/import/realm-config/consortia/catenax-shared/stable/master-realm.json
@@ -5209,7 +5209,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/generic/catenax-central/CX-Central-realm.json
+++ b/import/realm-config/generic/catenax-central/CX-Central-realm.json
@@ -6958,7 +6958,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/generic/catenax-shared/CX-Operator-realm.json
+++ b/import/realm-config/generic/catenax-shared/CX-Operator-realm.json
@@ -2127,7 +2127,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/import/realm-config/generic/catenax-shared/master-realm.json
+++ b/import/realm-config/generic/catenax-shared/master-realm.json
@@ -2690,7 +2690,7 @@
     "parRequestUriLifespan": "60",
     "clientSessionMaxLifespan": "0"
   },
-  "keycloakVersion": "22.0.3",
+  "keycloakVersion": "23.0.7",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []


### PR DESCRIPTION
## Description

- upgrade to keycloak v23.0.7
- feat(upgrade): set postgres version to 15 (latest available Bitnami image version: https://hub.docker.com/r/bitnami/postgresql/tags?page=1&name=15-debian-11)
- change version in realm config
- build and add updated init containers
- docs: update readme on root level
- docs: update readme templates on chart level with upgrade info
- docs: remove Catena-X from chart description
- chore(helm test): update version to upgrade from and k8s version

## Why

https://github.com/eclipse-tractusx/portal-iam/issues/62

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation