### PR TITLE
chore(upgrade-v23): improve database dependency

### DIFF
--- a/charts/centralidp/README.md.gotmpl
+++ b/charts/centralidp/README.md.gotmpl
@@ -57,7 +57,7 @@ Please see notes at [Values.seeding](values.yaml#L146) for upgrading the configu
 
 ### To 3.0.0
 
-This major changes from the Keycloak version from  22.0.3 to 23.0.7 and bumps the PostgresSQL version of the subchart from 15.4.0 to 15.6.0.
+This major changes from the Keycloak version from  22.0.3 to 23.0.7 and bumps the PostgresSQL version of the subchart from 15.4.0 to the latest available version of 15.
 
 No major issues are expected during the upgrade.
 

--- a/charts/centralidp/values.yaml
+++ b/charts/centralidp/values.yaml
@@ -107,6 +107,8 @@ keycloak:
     # Keycloak helm-chart from Bitnami has moved on to version 16.
     image:
       tag: "15-debian-11"
+    commonLabels:
+      app.kubernetes.io/version: "15"
     auth:
       # -- Non-root username.
       username: kccentral

--- a/charts/centralidp/values.yaml
+++ b/charts/centralidp/values.yaml
@@ -106,7 +106,7 @@ keycloak:
     # https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-07/#aligning-dependency-versions).
     # Keycloak helm-chart from Bitnami has moved on to version 16.
     image:
-      tag: "15"
+      tag: "15-debian-11"
     auth:
       # -- Non-root username.
       username: kccentral

--- a/charts/centralidp/values.yaml
+++ b/charts/centralidp/values.yaml
@@ -106,7 +106,7 @@ keycloak:
     # https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-07/#aligning-dependency-versions).
     # Keycloak helm-chart from Bitnami has moved on to version 16.
     image:
-      tag: "15.6.0"
+      tag: "15"
     auth:
       # -- Non-root username.
       username: kccentral

--- a/charts/sharedidp/README.md.gotmpl
+++ b/charts/sharedidp/README.md.gotmpl
@@ -63,7 +63,7 @@ Generate client-secrets for the service account with access type 'confidential'.
 
 ### To 3.0.0
 
-This major changes from the Keycloak version from  22.0.3 to 23.0.7 and bumps the PostgresSQL version of the subchart from 15.4.0 to 15.6.0.
+This major changes from the Keycloak version from  22.0.3 to 23.0.7 and bumps the PostgresSQL version of the subchart from 15.4.0 to the latest available version of 15.
 
 No major issues are expected during the upgrade.
 

--- a/charts/sharedidp/values.yaml
+++ b/charts/sharedidp/values.yaml
@@ -115,6 +115,8 @@ keycloak:
     # Keycloak helm-chart from Bitnami has moved on to version 16.
     image:
       tag: "15-debian-11"
+    commonLabels:
+      app.kubernetes.io/version: "15"
     auth:
       # -- Non-root username.
       username: kcshared

--- a/charts/sharedidp/values.yaml
+++ b/charts/sharedidp/values.yaml
@@ -114,7 +114,7 @@ keycloak:
     # https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-07/#aligning-dependency-versions).
     # Keycloak helm-chart from Bitnami has moved on to version 16.
     image:
-      tag: "15"
+      tag: "15-debian-11"
     auth:
       # -- Non-root username.
       username: kcshared

--- a/charts/sharedidp/values.yaml
+++ b/charts/sharedidp/values.yaml
@@ -114,7 +114,7 @@ keycloak:
     # https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-07/#aligning-dependency-versions).
     # Keycloak helm-chart from Bitnami has moved on to version 16.
     image:
-      tag: "15.6.0"
+      tag: "15"
     auth:
       # -- Non-root username.
       username: kcshared


### PR DESCRIPTION
## Description

- change to major tag for image to get latest minor updates
- set version label to major version
- use debian-11 image tag to remove collation version mismatch warning at upgrade
- docs: update upgrade info

## Why

follow up to https://github.com/eclipse-tractusx/portal-iam/pull/63

## Issue

#62 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation