### PR TITLE
chore: set resource limits for seeding and docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+###############################################################
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+---
+version: 2
+updates:
+  # Github Actions
+  -
+    package-ecosystem: "github-actions"
+    directory: /
+    labels:
+      - "dependabot"
+      - "github-actions"
+    schedule:
+      interval: "weekly"
+
+  # Docker
+  -
+    package-ecosystem: "docker"
+    directory: ./docker/
+    labels:
+      - "dependabot"
+      - "docker"
+    schedule:
+      interval: "weekly"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ Link to Github issue.
 
 Please delete options that are not relevant.
 
-- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
+- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/technical%20documentation/14.%20How%20to%20contribute.md)
 - [ ] I have added copyright and license headers, footers (for .md files) or files (for images) 
 - [ ] I have performed a self-review of my changes
 - [ ] I have successfully tested my changes

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # Chart dependencies
 **/charts/*.tgz
 Chart.lock
+**/values-local.yaml
 
 ### Visual Studio Code ###
 .vscode/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ The companies involved want to increase the automotive industry's
 competitiveness, improve efficiency through industry-specific cooperation and
 accelerate company processes through standardization and access to information
 and data. A special focus is also on SMEs, whose active participation is of
-central importance for the networkâ€™s success. That is why Catena-X has been
+central importance for the network's success. That is why Catena-X has been
 conceived from the outset as an open network with solutions ready for SMEs,
 where these companies will be able to participate quickly and with little IT
 infrastructure investment. Tractus-X is meant to be the PoC project of the
@@ -50,6 +50,10 @@ fulfills the DCO's requirement that you sign-off on your contributions.
 
 For more information, please see the Eclipse Committer Handbook:
 https://www.eclipse.org/projects/handbook/#resources-commit
+
+## How To Contribute
+
+For more practical information, please refer to [Contribution details](/docs/technical%20documentation/14.%20How%20to%20contribute.md).
 
 ## Contact
 

--- a/charts/centralidp/values.yaml
+++ b/charts/centralidp/values.yaml
@@ -167,15 +167,14 @@ seeding:
   excludedUserAttributes:
     attribute0: "bpn"
     attribute1: "organisation"
-  # -- We recommend not to specify default resource limits and to leave this as a conscious choice for the user.
-  # If you do want to specify resource limits, uncomment the following lines and adjust them as necessary.
+  # -- We recommend to review the default resource limits as this should a conscious choice.
   resources:
     requests:
-      cpu: 15m
-      memory: 105M
-    # limits:
-    #   cpu: 45m
-    #   memory: 105M
+      cpu: 75m
+      memory: 200M
+    limits:
+      cpu: 225m
+      memory: 200M
   extraVolumes:
     - name: realms
       emptyDir: {}

--- a/docs/technical documentation/14. How to contribute.md
+++ b/docs/technical documentation/14. How to contribute.md
@@ -1,0 +1,105 @@
+# Contribution details
+
+To contribute to the (CX) Identity & Access Management as part of the open source community, please read the details defined below.
+Besides a generic "how to", some commit and pull request (PR) guidelines are defined to ensure readability and make newly created PRs easier to review. Additionally, changelogs can get validated as well as written with more ease. Moreover, similar patterns are in use across the contributor community.
+
+**Content**:
+
+- [Commit How To](#how-to-contribute)
+- [Commit and PR guidelines](#commit-and-pr-guidelines)
+
+## How To Contribute
+
+### 1 Create a fork
+
+Open github - "eclipse-tractusx" project and select the respective repository to which you want to contribute.
+[Create a fork of the respective repo](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
+
+### 2 Fork setup
+
+Setup your fork by entering a name.
+
+Click "Create fork"
+
+### 3 Commit
+
+With the newly created fork, you can now start to contribute. Create a new branch in your own fork and start to implement the planned changes or new features.
+When the implementation is ready, create a PR against the original repository.
+
+The PR will get reviewed by the repository owners/official committers.
+As part of the pr review, sonarcloud will run automatically, and unit tests (if configured) will get executed. The PR owner is responsible to check the results and fix possible findings.
+
+## Commit and PR guidelines
+
+### Commits
+
+The suggestion is to use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+
+Here are some examples
+
+Feature branch:
+
+```mermaid
+%%{init: { 'logLevel': 'debug', 'theme': 'base' } }%%
+gitGraph
+    commit id: "release(1.0.0): merge in main"
+    checkout main
+    branch feature/feature1 order: 2
+    commit id:"feat(function): add feature1"
+    commit id:"feat(function): enable feature1"
+```
+
+Bugfix branch:
+
+```mermaid
+%%{init: { 'logLevel': 'debug', 'theme': 'base' } }%%
+gitGraph
+    commit id: "release(1.0.0): merge in main"
+    checkout main
+    branch bug/bug1
+    commit id: "fix(function): change bug1"
+    checkout bug/bug1
+    commit id:"fix(function): refactor bug1"
+```
+
+Release branch:
+
+```mermaid
+%%{init: { 'logLevel': 'debug', 'theme': 'base' } }%%
+gitGraph
+    commit id: "release: v1.0.0"
+    checkout main
+    branch release/1.1.0
+    commit id: "release(1.1.0): update version, changelog..." tag: "1.1.0"
+```
+
+Hotfix branch:
+
+```mermaid
+%%{init: { 'logLevel': 'debug', 'theme': 'base' } }%%
+gitGraph
+    commit id: "release: v1.0.0"
+    checkout main
+    branch release/1.1.0 order: 1
+    commit id: "release(1.1.0): update version, changelog..." tag: "1.1.0"
+    checkout release/1.1.0
+    branch hotfix/1.1.1 order: 2
+    commit id: "hotfix(1.1.1): update version, changelog..." tag: "1.1.1"
+```
+
+### PR title
+
+The suggested naming convention is '{type}{(function)}: {short summary}'
+
+### PR description
+
+Add details to the change, fix or feature in the PR description.
+What was changed, why was it changed (e.g. which issue was fixed or which requirement was implemented), and how was it changed.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2024 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/portal-iam


### PR DESCRIPTION
## Description

- chore(centralidp-seeding): set resource limits and increase requests
- docs: add contribution details
- chore: add dependabot.yml file
- chore(gitignore): add local values file

## Why

#54
eclipse-tractusx/portal#219

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have added copyright and license headers, footers (for .md files) or files (for images) 
- [x] I have performed a self-review of my changes
