### PR TITLE
fix(consortia): remove obsolete client from user role mappings

### DIFF
--- a/import/realm-config/consortia/catenax-central/beta/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/beta/CX-Central-realm.json
@@ -2909,7 +2909,6 @@
       "realmRoles" : [ "default-roles-catena-x realm" ],
       "clientRoles" : {
         "Cl15-CX-DFT" : [ "User" ],
-        "Cl9-CDQ-Fraud" : [ "fraud_app_user" ],
         "Cl1-CX-Registration" : [ "CX Admin", "Company Admin" ],
         "Cl2-CX-Portal" : [ "CX User" ]
       },
@@ -2998,7 +2997,6 @@
       "realmRoles" : [ "default-roles-catena-x realm" ],
       "clientRoles" : {
         "Cl16-CX-CRisk" : [ "Company Admin", "User" ],
-        "Cl9-CDQ-Fraud" : [ "fraud_app_manager", "fraud_app_user" ],
         "technical_roles_management" : [ "BPDM Management" ],
         "Cl1-CX-Registration" : [ "CX Admin" ],
         "Cl2-CX-Portal" : [ "CX Admin" ]

--- a/import/realm-config/consortia/catenax-central/dev/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/dev/CX-Central-realm.json
@@ -2909,7 +2909,6 @@
       "realmRoles" : [ "default-roles-catena-x realm" ],
       "clientRoles" : {
         "Cl15-CX-DFT" : [ "User" ],
-        "Cl9-CDQ-Fraud" : [ "fraud_app_user" ],
         "Cl1-CX-Registration" : [ "CX Admin", "Company Admin" ],
         "Cl2-CX-Portal" : [ "CX User" ]
       },
@@ -2998,7 +2997,6 @@
       "realmRoles" : [ "default-roles-catena-x realm" ],
       "clientRoles" : {
         "Cl16-CX-CRisk" : [ "Company Admin", "User" ],
-        "Cl9-CDQ-Fraud" : [ "fraud_app_manager", "fraud_app_user" ],
         "technical_roles_management" : [ "BPDM Management" ],
         "Cl1-CX-Registration" : [ "CX Admin" ],
         "Cl2-CX-Portal" : [ "CX Admin" ]

--- a/import/realm-config/consortia/catenax-central/int/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/int/CX-Central-realm.json
@@ -2909,7 +2909,6 @@
       "realmRoles" : [ "default-roles-catena-x realm" ],
       "clientRoles" : {
         "Cl15-CX-DFT" : [ "User" ],
-        "Cl9-CDQ-Fraud" : [ "fraud_app_user" ],
         "Cl1-CX-Registration" : [ "CX Admin", "Company Admin" ],
         "Cl2-CX-Portal" : [ "CX User" ]
       },
@@ -2998,7 +2997,6 @@
       "realmRoles" : [ "default-roles-catena-x realm" ],
       "clientRoles" : {
         "Cl16-CX-CRisk" : [ "Company Admin", "User" ],
-        "Cl9-CDQ-Fraud" : [ "fraud_app_manager", "fraud_app_user" ],
         "technical_roles_management" : [ "BPDM Management" ],
         "Cl1-CX-Registration" : [ "CX Admin" ],
         "Cl2-CX-Portal" : [ "CX Admin" ]

--- a/import/realm-config/consortia/catenax-central/pen/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/pen/CX-Central-realm.json
@@ -2909,7 +2909,6 @@
       "realmRoles" : [ "default-roles-catena-x realm" ],
       "clientRoles" : {
         "Cl15-CX-DFT" : [ "User" ],
-        "Cl9-CDQ-Fraud" : [ "fraud_app_user" ],
         "Cl1-CX-Registration" : [ "CX Admin", "Company Admin" ],
         "Cl2-CX-Portal" : [ "CX User" ]
       },
@@ -2998,7 +2997,6 @@
       "realmRoles" : [ "default-roles-catena-x realm" ],
       "clientRoles" : {
         "Cl16-CX-CRisk" : [ "Company Admin", "User" ],
-        "Cl9-CDQ-Fraud" : [ "fraud_app_manager", "fraud_app_user" ],
         "technical_roles_management" : [ "BPDM Management" ],
         "Cl1-CX-Registration" : [ "CX Admin" ],
         "Cl2-CX-Portal" : [ "CX Admin" ]

--- a/import/realm-config/consortia/catenax-central/rc/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/rc/CX-Central-realm.json
@@ -2909,7 +2909,6 @@
       "realmRoles" : [ "default-roles-catena-x realm" ],
       "clientRoles" : {
         "Cl15-CX-DFT" : [ "User" ],
-        "Cl9-CDQ-Fraud" : [ "fraud_app_user" ],
         "Cl1-CX-Registration" : [ "CX Admin", "Company Admin" ],
         "Cl2-CX-Portal" : [ "CX User" ]
       },
@@ -2998,7 +2997,6 @@
       "realmRoles" : [ "default-roles-catena-x realm" ],
       "clientRoles" : {
         "Cl16-CX-CRisk" : [ "Company Admin", "User" ],
-        "Cl9-CDQ-Fraud" : [ "fraud_app_manager", "fraud_app_user" ],
         "technical_roles_management" : [ "BPDM Management" ],
         "Cl1-CX-Registration" : [ "CX Admin" ],
         "Cl2-CX-Portal" : [ "CX Admin" ]

--- a/import/realm-config/consortia/catenax-central/stable/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/stable/CX-Central-realm.json
@@ -2909,7 +2909,6 @@
       "realmRoles" : [ "default-roles-catena-x realm" ],
       "clientRoles" : {
         "Cl15-CX-DFT" : [ "User" ],
-        "Cl9-CDQ-Fraud" : [ "fraud_app_user" ],
         "Cl1-CX-Registration" : [ "CX Admin", "Company Admin" ],
         "Cl2-CX-Portal" : [ "CX User" ]
       },
@@ -2998,7 +2997,6 @@
       "realmRoles" : [ "default-roles-catena-x realm" ],
       "clientRoles" : {
         "Cl16-CX-CRisk" : [ "Company Admin", "User" ],
-        "Cl9-CDQ-Fraud" : [ "fraud_app_manager", "fraud_app_user" ],
         "technical_roles_management" : [ "BPDM Management" ],
         "Cl1-CX-Registration" : [ "CX Admin" ],
         "Cl2-CX-Portal" : [ "CX Admin" ]


### PR DESCRIPTION
## Description

remove Cl9-CDQ-Fraud client from user role mappings in CX-Central consortia data.

## Why

Forgot role mapping when removing client.
Keycloak server doesn't start up.

## Issue

https://github.com/eclipse-tractusx/portal-iam/issues/66

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/technical%20documentation/14.%20How%20to%20contribute.md)
- [x] I have performed a self-review of my changes
