### PR TITLE
chore(consortia): disable default seeding on dev and rc

### DIFF
--- a/consortia/environments/centralidp/values-dev.yaml
+++ b/consortia/environments/centralidp/values-dev.yaml
@@ -66,7 +66,7 @@ secrets:
         replicationPassword: "<path:portal/data/dev/iam/centralidp-postgres#replication-password>"
 
 seeding:
-  enabled: true
+  enabled: false
   image: "docker.io/tractusx/portal-iam-seeding:dev"
   initContainers:
     - name: init-cx-central

--- a/consortia/environments/centralidp/values-rc.yaml
+++ b/consortia/environments/centralidp/values-rc.yaml
@@ -66,7 +66,7 @@ secrets:
         replicationPassword: "<path:portal/data/dev/iam/centralidp-postgres#replication-password>"
 
 seeding:
-  enabled: true
+  enabled: false
   initContainers:
     - name: init-cx-central
       image: docker.io/tractusx/portal-iam-consortia:v3.0.0-rc.1


### PR DESCRIPTION
## Description

consortia: disable default seeding on dev and rc

## Why

chore

## Issue

Link to Github issue.

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/technical%20documentation/14.%20How%20to%20contribute.md)
- [x] I have successfully tested my changes
