### PR TITLE
chore: fix json syntax error in sharedidp master realm

### DIFF
--- a/import/realm-config/generic/catenax-shared/master-realm.json
+++ b/import/realm-config/generic/catenax-shared/master-realm.json
@@ -2698,4 +2698,4 @@
   "clientPolicies": {
     "policies": []
   }
-}‚
+}


### PR DESCRIPTION
## Description

- fix json syntax error in sharedidp master import realm

## Why

invalid json syntax at the end of the file

## Issue

na

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/technical%20documentation/14.%20How%20to%20contribute.md)
- [x] I have performed a self-review of my changes
