### PR TITLE
fix(theme): remove password username check

### DIFF
--- a/import/keycloak-themes/catenax-shared/login/resources/js/Main.js
+++ b/import/keycloak-themes/catenax-shared/login/resources/js/Main.js
@@ -136,7 +136,6 @@ const Messages = {
         HAS_UPPER: 'contains upper case characters [A-Z]',
         HAS_NUMBER: 'contains numbers [0-9]',
         HAS_SPECIAL: 'contains characters other than [a-z] [A-Z] [0-9]',
-        NOT_USERNAME: 'is not equal to your username',
         OK_CONFIRM: 'confirmation and password are equal',
     }
 }
@@ -150,7 +149,6 @@ class Validator {
         ['HAS_UPPER', /[A-Z]/],
         ['HAS_NUMBER', /\d/],
         ['HAS_SPECIAL', /[^a-zA-Z0-9]/],
-        ['NOT_USERNAME', (expr) => expr !== '' && expr !== State.getInstance().atts.username],
         ['OK_CONFIRM', (expr) => expr !== '' && expr === State.getInstance().atts.confirm],
     ]
 


### PR DESCRIPTION
## Description

Remove check not equal to username in password update

## Why

In the updated keycloak base form the username is not visible any more and we have no value to check for.

## Issue

https://github.com/eclipse-tractusx/portal-iam/issues/100

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/technical%20documentation/14.%20How%20to%20contribute.md)
- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes