### PR TITLE
fix(theme): fix password update for portal

### DIFF
--- a/import/keycloak-themes/catenax-shared-portal/login/resources/css/Main.css
+++ b/import/keycloak-themes/catenax-shared-portal/login/resources/css/Main.css
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -232,6 +232,15 @@ form a {
 
 #kc-form-buttons {
   padding: 16px 0px;
+}
+
+button[aria-controls="password-new"],
+button[aria-controls="password-confirm"] {
+  display: none;
+}
+
+#logout-sessions {
+  width: 20px;
 }
 
 .password-policy-hint {


### PR DESCRIPTION
## Description

Remove empty buttons from portal login theme password update page.

## Why

Two empty buttons were shown under the password and confirm password field also the "sign out from all devices" checkbox was not aligned.

## Issue

#100, #108

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/technical%20documentation/14.%20How%20to%20contribute.md)
- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes