### PR TITLE
feat: add BPDM authentication configuration for 24.08. release

### DIFF
--- a/docs/technical documentation/03. Clients.md
+++ b/docs/technical documentation/03. Clients.md
@@ -34,6 +34,7 @@ During the [import of the realms](/import/realm-config/) at startup, the relevan
 | CentralIdP | Public | SSI Credential Issuer | Cl24-CX-SSI-CredentialIssuer |
 | CentralIdP | Confidential | BPDM | Cl7-CX-BPDM |
 | CentralIdP | Confidential | BPDM Portal Gate | Cl16-CX-BPDMGate |
+| CentralIdP | Confidential | BPDM Orchestrator | Cl25-CX-BPDM-Orchestrator |
 | CentralIdP | Confidential | Managed Identity Wallet | Cl5-CX-Custodian |
 | CentralIdP | Service Account | Portal Backend to call Keycloak | sa-cl1-reg-2 |
 | CentralIdP | Service Account | Clearinghouse update application | sa-cl2-01 |
@@ -49,6 +50,10 @@ During the [import of the realms](/import/realm-config/) at startup, the relevan
 | CentralIdP | Service Account | SSI Credential Issuer | sa-cl24-01 |
 | CentralIdP | Service Account | SSI Credential Issuer - Portal to SSI Credential Issuer | sa-cl2-04 |
 | CentralIdP | Service Account | DIM (Decentral Identity Management) Middle Layer to Portal | sa-cl2-05 |
+| CentralIdP | Service Account | BPDM Dummy Cleaning Task Processor | sa-cl25-cx-1 |
+| CentralIdP | Service Account | BPDM Pool Task Processor | sa-cl25-cx-2 |
+| CentralIdP | Service Account | BPDM Portal Gate Task Creator | sa-cl25-cx-3 |
+| CentralIdP | Service Account | BPDM Portal Gate Pool Consumer | sa-cl7-cx-1 |
 | SharedIdP | Service Account | in master realm for Portal Backend to call Keycloak | sa-cl1-reg-1 |
 
 ## Client Authentication Concept

--- a/docs/technical documentation/06. Roles & Rights Concept.md
+++ b/docs/technical documentation/06. Roles & Rights Concept.md
@@ -276,25 +276,31 @@ For example:
 
 Managed via Client: **Cl7-CX-BPDM**
 
-| | **CX Admin** | **Technical User*** | **Company Admin** | **Business Admin** | **IT Admin** | **CX User** | **Purchaser** | **App Manager** | **App Developer** | **Sales Manager** | **Service Manager** | **Business Partner Data Manager** |
-|-|----------|-----------------|---------------|----------------|----------|---------|-----------|-------------|----------|------|-----------|--------------|
-|Business Partner Data Management| | | | By role "BPDM Pool Consumer" | By role "BPDM Pool Consumer" | By role "BPDM Pool Consumer" | By role "BPDM Pool Consumer" | By role "BPDM Pool Consumer" | By role "BPDM Pool Consumer" | By role "BPDM Pool Consumer" | By role "BPDM Pool Consumer" | |
-| read_changelog **new** | x | x | x | x | x | x | x | x | x | x | x | x |
-| read_changelog_member **new** | x | x | x | x | x | x | x | x | x | x | x | x |
-| read_metadata **new** | x | x | | | | | | | | | | x |
-| read_partner **new** | x | x | | | | | | | | | | |
-| read_partner_member **new** | x | x | x | | | | | | | | | |
-| write_metadata **new** | x | x | x | x | x | x | x | x | x | x | x | x |
-| write_partner **new** | x | x | | | | | | | | | | |
+|                                  |  **CX Admin** | **Technical User*** | **Company Admin** | **Business Admin**           | **IT Admin**                 | **CX User**                  | **Purchaser**                | **App Manager**              | **App Developer**            | **Sales Manager**            | **Service Manager**          | **Business Partner Data Manager** |
+|----------------------------------|---------------|---------------------|-------------------|------------------------------|------------------------------|------------------------------|------------------------------|------------------------------|------------------------------|------------------------------|------------------------------|-----------------------------------|
+| Business Partner Data Management |               |                     |                   | By role "BPDM Pool Consumer" | By role "BPDM Pool Consumer" | By role "BPDM Pool Consumer" | By role "BPDM Pool Consumer" | By role "BPDM Pool Consumer" | By role "BPDM Pool Consumer" | By role "BPDM Pool Consumer" | By role "BPDM Pool Consumer" |                                   |
+| read_changelog                   | x             | x                   |  x                | x                            | x                            | x                            | x                            | x                            | x                            | x                            | x                            | x                                 |
+| read_changelog_member            | x             | x                   |  x                | x                            | x                            | x                            | x                            | x                            | x                            | x                            | x                            | x                                 |
+| read_metadata                    | x             | x                   |                   |                              |                              |                              |                              |                              |                              |                              |                              | x                                 |
+| read_partner                     | x             | x                   |                   |                              |                              |                              |                              |                              |                              |                              |                              |                                   |
+| read_partner_member              | x             | x                   | x                 |                              |                              |                              |                              |                              |                              |                              |                              |                                   |
+| write_metadata                   | x             | x                   |  x                | x                            | x                            | x                            | x                            | x                            | x                            | x                            | x                            | x                                 |
+| write_partner                    | x             | x                   |                   |                              |                              |                              |                              |                              |                              |                              |                              |                                   |
 
-Technical Users*: BPDM Admin & BPDM Pool Consumer.
+Technical Users*: BPDM Admin, BPDM Pool Consumer & BPDM Pool Sharing Consumer.
 
 Following the permission assignment
 
 - BPDM Pool Consumer
-  - read_changelog
+  - read_partner_member
   - read_changelog_member
   - read_metadata
+  
+- BPDM Pool Sharing Consumer
+  - read_partner
+  - read_metadata
+  - read_changelog
+
 - BPDM Pool Admin
   - read_partner
   - write_partner
@@ -305,7 +311,7 @@ Following the permission assignment
   - write_metadata
 
 >**_NOTE_:**
-> BPDM Admin as well as BPDM Pool Consumer is only available for the CX-Operator.
+> All technical roles are only available for the CX-Operator.
 No other customers can create such technical user roles.
 
 #### 2.5.6 BPDM Gate
@@ -313,18 +319,16 @@ No other customers can create such technical user roles.
 Managed via Client: **Cl16-CX-BPDMGate**
 As well as on runtime created gates
 
-| | **CX Admin** | **Technical User*** | **Company Admin** | **Business Admin** | **IT Admin** | **CX User** | **Purchaser** | **App Manager** | **App Developer** | **Sales Manager** | **Service Manager** | **Business Partner Data Manager** |
-|-|----------|-----------------|---------------|----------------|----------|---------|-----------|-------------|----------|------|-----------|--------------|
-|Business Partner Data Management| | | | | | | | | | | | |
-| read_input_partner | | x | | | | | | | | | | |
-| write_input_partner - exclusively for the platform operator | | x | | | | | | | | | | |
-| read_input_changelog | | x | | | | | | | | | | |
-| read_output_partner | | x | | | | | | | | | | |
-| write_output_partner - exclusively for the platform operator | | x | | | | | | | | | | |
-| read_output_changelog | | x | | | | | | | | | | |
-| read_sharing_state | | x | | | | | | | | | | |
-| write_sharing_state - exclusively for the platform operator | | | | | | | | | | | | |
-| read_stats | | x | | | | | | | | | | |
+|                       |  **CX Admin** | **Technical User*** | **Company Admin** | **Business Admin** | **IT Admin** | **CX User** | **Purchaser** | **App Manager** | **App Developer** | **Sales Manager** | **Service Manager** | **Business Partner Data Manager** |
+|-----------------------|---------------|---------------------|-------------------|--------------------|--------------|-------------|---------------|-----------------|-------------------|-------------------|---------------------|-----------------------------------|
+| read_input_partner    |               | x                   |                   |                    |              |             |               |                 |                   |                   |                     | x                                 |
+| write_input_partner   |               | x                   |                   |                    |              |             |               |                 |                   |                   |                     | x                                 |
+| read_input_changelog  |               | x                   |                   |                    |              |             |               |                 |                   |                   |                     | x                                 |
+| read_output_partner   |               | x                   |                   |                    |              |             |               |                 |                   |                   |                     | x                                 |
+| read_output_changelog |               | x                   |                   |                    |              |             |               |                 |                   |                   |                     | x                                 |
+| read_sharing_state    |               | x                   |                   |                    |              |             |               |                 |                   |                   |                     | x                                 |
+| write_sharing_state   |               | x                   |                   |                    |              |             |               |                 |                   |                   |                     | x                                 |
+| read_stats            |               | x                   |                   |                    |              |             |               |                 |                   |                   |                     | x                                 |
 
 Technical Users Roles/Profiles:
 
@@ -340,7 +344,6 @@ Following the permission assignment
   - write_input_partner
   - read_input_changelog
   - read_output_partner
-  - write_output_partner
   - read_output_changelog
   - read_sharing_state
   - write_sharing_state
@@ -393,6 +396,70 @@ Managed via Client: **Cl24-CX-SSI-CredentialIssuer**
 | View owned credential request (view_certificates) | x | | x | x | x | x | x | x | x | x | x | x |
 | Revoke owned credentials (revoke_credential) | x | | x | x | x | | | | | | | |
 | Revoke any credentials (revoke_credential_issuer) | x | | | | | | | | | | | |
+
+#### 2.5.6 BPDM Orchestrator
+
+Managed via Client: **Cl25-CX-BPDM-Orchestrator**
+
+|                                 |  **CX Admin** | **Technical User*** | **Company Admin** | **Business Admin** | **IT Admin** | **CX User** | **Purchaser** | **App Manager** | **App Developer** | **Sales Manager** | **Service Manager** | **Business Partner Data Manager** |
+|---------------------------------|---------------|---------------------|-------------------|--------------------|--------------|-------------|---------------|-----------------|-------------------|-------------------|---------------------|-----------------------------------|
+| create_task                     |               | x                   |                   |                    |              |             |               |                 |                   |                   |                     |                                   |
+| read_task                       |               | x                   |                   |                    |              |             |               |                 |                   |                   |                     |                                   |
+| create_reservation_clean        |               | x                   |                   |                    |              |             |               |                 |                   |                   |                     |                                   |
+| create_result_clean             |               | x                   |                   |                    |              |             |               |                 |                   |                   |                     |                                   |
+| create_reservation_cleanAndSync |               | x                   |                   |                    |              |             |               |                 |                   |                   |                     |                                   |
+| create_result_cleanAndSync      |               | x                   |                   |                    |              |             |               |                 |                   |                   |                     |                                   |
+| create_reservation_poolSync     |               | x                   |                   |                    |              |             |               |                 |                   |                   |                     |                                   |
+| create_result_poolSync          |               | x                   |                   |                    |              |             |               |                 |                   |                   |                     |                                   |
+
+
+Technical Users Roles/Profiles:
+- BPDM Orchestrator Admin
+- BPDM Orchestrator Task Creator
+- BPDM Orchestrator Processor Clean
+- BPDM Orchestrator Processor CleanAndSync
+- BPDM Orchestrator Processor PoolSync
+
+Following the permission assignment
+
+- BPDM Orchestrator Admin:
+  - create_task
+  - read_task
+  - create_reservation_clean
+  - create_result_clean
+  - create_reservation_cleanAndSync
+  - create_result_cleanAndSync
+  - create_reservation_poolSync
+  - create_result_poolSync
+
+- BPDM Orchestrator Task Creator
+  - create_task
+  - read_task
+  
+- BPDM Orchestrator Processor Clean
+  - create_reservation_clean
+  - create_result_clean
+
+- BPDM Orchestrator Processor CleanAndSync
+  - create_reservation_cleanAndSync
+  - create_result_cleanAndSync
+
+- BPDM Orchestrator Processor PoolSync
+  - create_reservation_poolSync
+  - create_result_poolSync
+
+>**_NOTE:_**
+>All technical roles are only available for the Operator.
+No other customers can create such technical user roles.
+
+
+Following Tech User Roles are available for the Operator via the Self-Service:
+
+- BPDM Orchestrator Admin
+- BPDM Orchestrator Task Creator
+- BPDM Orchestrator Processor Clean
+- BPDM Orchestrator Processor CleanAndSync
+- BPDM Orchestrator Processor PoolSync
 
 ### 2.6 Segregation of duties
 

--- a/import/realm-config/generic/catenax-central/CX-Central-realm.json
+++ b/import/realm-config/generic/catenax-central/CX-Central-realm.json
@@ -873,13 +873,10 @@
           "composite": true,
           "composites": {
             "client": {
-              "Cl7-CX-BPDM": [
-                "read_metadata",
-                "read_partner_member",
-                "read_changelog_member"
-              ],
               "technical_roles_management": [
-                "BPDM Pool Consumer"
+                "BPDM Pool Consumer",
+                "BPDM Sharing Output Consumer",
+                "BPDM Sharing Input Manager"
               ],
               "Cl24-CX-SSI-CredentialIssuer": [
                 "view_credential_requests"
@@ -908,11 +905,6 @@
           "composite": true,
           "composites": {
             "client": {
-              "Cl7-CX-BPDM": [
-                "read_changelog_member",
-                "read_partner_member",
-                "read_metadata"
-              ],
               "technical_roles_management": [
                 "BPDM Pool Consumer"
               ],
@@ -1276,7 +1268,6 @@
             "client": {
               "Cl16-CX-BPDMGate": [
                 "read_input_changelog",
-                "write_output_partner",
                 "read_output_changelog",
                 "read_output_partner",
                 "read_input_partner",
@@ -1844,8 +1835,8 @@
             "client": {
               "Cl7-CX-BPDM": [
                 "read_metadata",
-                "read_changelog",
-                "read_changelog_member"
+                "read_changelog_member",
+                "read_partner_member"
               ]
             }
           },
@@ -1885,7 +1876,6 @@
             "client": {
               "Cl16-CX-BPDMGate": [
                 "read_input_changelog",
-                "write_output_partner",
                 "read_output_changelog",
                 "read_stats",
                 "write_sharing_state",
@@ -1942,8 +1932,7 @@
               "Cl7-CX-BPDM": [
                 "read_metadata",
                 "read_changelog",
-                "read_partner_member",
-                "read_changelog_member"
+                "read_partner"
               ]
             }
           },
@@ -2260,15 +2249,6 @@
         {
           "id": "913fa128-8614-49c9-9214-93958fc69758",
           "name": "read_input_changelog",
-          "description": "",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "52f90723-b4c1-44c3-bef2-fd8ebe59ae6c",
-          "attributes": {}
-        },
-        {
-          "id": "08009ffe-2058-4fcd-82ef-12ee52d86557",
-          "name": "write_output_partner",
           "description": "",
           "composite": false,
           "clientRole": true,

--- a/import/realm-config/generic/catenax-central/CX-Central-realm.json
+++ b/import/realm-config/generic/catenax-central/CX-Central-realm.json
@@ -1623,6 +1623,80 @@
           "attributes": {}
         }
       ],
+      "Cl25-CX-BPDM-Orchestrator": [
+        {
+          "id": "4b20dc8b-0231-41a0-acef-662ed5353c18",
+          "name": "create_result_poolSync",
+          "description": "Allowed to create results for reserved golden record tasks in the 'PoolSync' queue.",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "632271be-e00c-47c2-b2e9-4b12d75c8c5b",
+          "attributes": {}
+        },
+        {
+          "id": "0a5befef-6ecf-4bc8-ab94-7f0e3731c858",
+          "name": "read_task",
+          "description": "Allowed to read the processing state and result of golden record tasks.",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "632271be-e00c-47c2-b2e9-4b12d75c8c5b",
+          "attributes": {}
+        },
+        {
+          "id": "4632b001-25e2-4ef8-bd04-05f7b9e0453d",
+          "name": "create_result_cleanAndSync",
+          "description": "Allowed to create results for reserved golden record tasks in the 'CleanAndSync' queue.",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "632271be-e00c-47c2-b2e9-4b12d75c8c5b",
+          "attributes": {}
+        },
+        {
+          "id": "d335c39d-d160-40d6-86b1-11a6e1889ddd",
+          "name": "create_task",
+          "description": "Allowed to create new golden record tasks",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "632271be-e00c-47c2-b2e9-4b12d75c8c5b",
+          "attributes": {}
+        },
+        {
+          "id": "1f15361f-c5ee-40e5-9169-fd32b3d0c8da",
+          "name": "create_reservation_clean",
+          "description": "Allowed to create reservations for golden record tasks inside the 'Clean' queue.",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "632271be-e00c-47c2-b2e9-4b12d75c8c5b",
+          "attributes": {}
+        },
+        {
+          "id": "90451361-9282-4cee-bb43-96f084a43d7e",
+          "name": "create_reservation_poolSync",
+          "description": "Allowed to create reservations for golden record tasks in the 'PoolSync' queue.",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "632271be-e00c-47c2-b2e9-4b12d75c8c5b",
+          "attributes": {}
+        },
+        {
+          "id": "f972bf5c-7454-4c3f-882b-0535eacd7dd9",
+          "name": "create_result_clean",
+          "description": "Allowed to create results for reserved golden record tasks in the 'Clean' queue.",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "632271be-e00c-47c2-b2e9-4b12d75c8c5b",
+          "attributes": {}
+        },
+        {
+          "id": "dbb4cbda-671b-4b8c-8ed8-a9c3e8ad7256",
+          "name": "create_reservation_cleanAndSync",
+          "description": "Allowed to create reservations for golden record tasks in the 'CleanAndSync' queue",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "632271be-e00c-47c2-b2e9-4b12d75c8c5b",
+          "attributes": {}
+        }
+      ],
       "technical_roles_management": [
         {
           "id": "1e3bef93-036c-44a8-b37a-04ca9effcfcb",
@@ -1866,6 +1940,97 @@
                 "read_changelog",
                 "read_partner_member",
                 "read_changelog_member"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
+          "attributes": {}
+        },
+        {
+          "id": "3fbeeb23-c281-43a4-b76a-f0805e919905",
+          "name": "BPDM Orchestrator Admin",
+          "description": "Full read and write access to the BPDM Orchestrator component",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl25-CX-BPDM-Orchestrator": [
+                "create_result_poolSync",
+                "read_task",
+                "create_result_cleanAndSync",
+                "create_task",
+                "create_reservation_clean",
+                "create_reservation_poolSync",
+                "create_result_clean",
+                "create_reservation_cleanAndSync"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
+          "attributes": {}
+        },
+        {
+          "id": "a0dab74a-13d2-4ced-b0af-fa8a3894c2ec",
+          "name": "BPDM Orchestrator Task Creator",
+          "description": "Allowed to create new golden record tasks, monitor the processing state and result.",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl25-CX-BPDM-Orchestrator": [
+                "read_task",
+                "create_task"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
+          "attributes": {}
+        },
+        {
+          "id": "efb560b1-3649-4af9-931e-4799c61504e6",
+          "name": "BPDM Orchestrator Processor Clean",
+          "description": "Allowed to process golden record tasks in the 'Clean' queue",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl25-CX-BPDM-Orchestrator": [
+                "create_reservation_clean",
+                "create_result_clean"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
+          "attributes": {}
+        },
+        {
+          "id": "4444626e-b5dd-4c8d-8897-0b7ad3ccdf21",
+          "name": "BPDM Orchestrator Processor CleanAndSync",
+          "description": "Allowed to process golden record tasks in the 'CleanAndSync' queue",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl25-CX-BPDM-Orchestrator": [
+                "create_result_cleanAndSync",
+                "create_reservation_cleanAndSync"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
+          "attributes": {}
+        },
+        {
+          "id": "a1e82d28-ab78-40ac-aae5-cda1f3615c61",
+          "name": "BPDM Orchestrator Processor PoolSync",
+          "description": "Allowed to process golden record tasks in the 'PoolSync' queue",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl25-CX-BPDM-Orchestrator": [
+                "create_result_poolSync",
+                "create_reservation_poolSync"
               ]
             }
           },
@@ -2986,7 +3151,8 @@
       "clientRoles": {
         "technical_roles_management": [
           "BPDM Sharing Admin",
-          "BPDM Pool Admin"
+          "BPDM Pool Admin",
+          "BPDM Orchestrator Admin"
         ]
       },
       "notBefore": 0,
@@ -3013,7 +3179,8 @@
       "clientRoles": {
         "technical_roles_management": [
           "BPDM Sharing Admin",
-          "BPDM Pool Admin"
+          "BPDM Pool Admin",
+          "BPDM Orchestrator Admin"
         ]
       },
       "notBefore": 0,
@@ -3098,14 +3265,16 @@
         "client": "sa-cl7-cx-5",
         "roles": [
           "BPDM Pool Admin",
-          "BPDM Sharing Admin"
+          "BPDM Sharing Admin",
+          "BPDM Orchestrator Admin"
         ]
       },
       {
         "client": "sa-cl7-cx-7",
         "roles": [
           "BPDM Pool Admin",
-          "BPDM Sharing Admin"
+          "BPDM Sharing Admin",
+          "BPDM Orchestrator Admin"
         ]
       }
     ],
@@ -4206,6 +4375,117 @@
       "authenticationFlowBindingOverrides": {},
       "fullScopeAllowed": true,
       "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "983159fa-37f3-4519-9c98-8fe23d8ab8bf",
+      "clientId": "Cl25-CX-BPDM-Orchestrator",
+      "name": "BPDM Orchestrator",
+      "description": "Roles resource for the BPDM Orchestrator component",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": false,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "oidc.ciba.grant.enabled": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "client.secret.creation.time": "1722276592",
+        "backchannel.logout.session.required": "true",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "de42377c-8b7a-466c-91d6-c95d8a8533b8",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "3f29cf79-e84c-4c1a-bf71-29238f655bfc",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "831b2dfd-0c87-4328-b5ed-49a4efced60e",
+          "name": "BPN",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "bpn",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "bpn",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "200ce257-7bee-4662-988a-750bf3e03790",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        }
+      ],
       "defaultClientScopes": [
         "web-origins",
         "roles",

--- a/import/realm-config/generic/catenax-central/CX-Central-realm.json
+++ b/import/realm-config/generic/catenax-central/CX-Central-realm.json
@@ -1697,6 +1697,10 @@
           "attributes": {}
         }
       ],
+      "sa-cl25-cx-1": [],
+      "sa-cl25-cx-2": [],
+      "sa-cl25-cx-3": [],
+      "sa-cl7-cx-1": [],
       "technical_roles_management": [
         {
           "id": "1e3bef93-036c-44a8-b37a-04ca9effcfcb",
@@ -3159,6 +3163,85 @@
       "groups": []
     },
     {
+      "id": "e24da044-7290-45f4-a2ea-cb8165393f0a",
+      "createdTimestamp": 1722276592957,
+      "username": "service-account-sa-cl25-cx-2",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "serviceAccountClientId": "sa-cl25-cx-2",
+      "attributes": {
+        "bpn": [
+          "BPNL00000003CRHK"
+        ]
+      },
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-cx-central"
+      ],
+      "clientRoles": {
+        "technical_roles_management": [
+          "BPDM Orchestrator Processor PoolSync"
+        ]
+      },
+      "notBefore": 0,
+      "groups": []
+    },
+    {
+      "id": "72351810-a1b4-42e6-9686-8abe6b0d5cb0",
+      "createdTimestamp": 1722276592957,
+      "username": "service-account-sa-cl25-cx-3",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "serviceAccountClientId": "sa-cl25-cx-3",
+      "attributes": {
+        "bpn": [
+          "BPNL00000003CRHK"
+        ]
+      },
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-cx-central"
+      ],
+      "clientRoles": {
+        "technical_roles_management": [
+          "BPDM Orchestrator Task Creator"
+        ]
+      },
+      "notBefore": 0,
+      "groups": []
+    },
+    {
+      "id": "bbb919dd-b3aa-4ec3-8786-582787886276",
+      "createdTimestamp": 1722276592957,
+      "username": "service-account-sa-cl25-cx-1",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "serviceAccountClientId": "sa-cl25-cx-1",
+      "attributes": {
+        "bpn": [
+          "BPNL00000003CRHK"
+        ]
+      },
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-cx-central"
+      ],
+      "clientRoles": {
+        "technical_roles_management": [
+          "BPDM Orchestrator Processor CleanAndSync",
+          "BPDM Orchestrator Processor Clean"
+        ]
+      },
+      "notBefore": 0,
+      "groups": []
+    },
+    {
       "id": "3f9fc7e8-d312-4912-a9a1-4db8849ce8f7",
       "createdTimestamp": 1722276592957,
       "username": "service-account-sa-cl7-cx-7",
@@ -3207,6 +3290,32 @@
       "clientRoles": {
         "Cl2-CX-Portal": [
           "add_self_descriptions"
+        ]
+      },
+      "notBefore": 0,
+      "groups": []
+    },
+    {
+      "id": "95796de5-c9c6-46fc-a3f7-7af782ea9024",
+      "createdTimestamp": 1722276592957,
+      "username": "service-account-sa-cl7-cx-1",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "serviceAccountClientId": "sa-cl7-cx-1",
+      "attributes": {
+        "bpn": [
+          "BPNL00000003CRHK"
+        ]
+      },
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-cx-central"
+      ],
+      "clientRoles": {
+        "technical_roles_management": [
+          "BPDM Pool Sharing Consumer"
         ]
       },
       "notBefore": 0,
@@ -3275,6 +3384,31 @@
           "BPDM Pool Admin",
           "BPDM Sharing Admin",
           "BPDM Orchestrator Admin"
+        ]
+      },
+      {
+        "client": "sa-cl25-cx-1",
+        "roles": [
+          "BPDM Orchestrator Processor CleanAndSync",
+          "BPDM Orchestrator Processor Clean"
+        ]
+      },
+      {
+        "client": "sa-cl25-cx-2",
+        "roles": [
+          "BPDM Orchestrator Processor PoolSync"
+        ]
+      },
+      {
+        "client": "sa-cl25-cx-3",
+        "roles": [
+          "BPDM Orchestrator Task Creator"
+        ]
+      },
+      {
+        "client": "sa-cl7-cx-1",
+        "roles": [
+          "BPDM Pool Sharing Consumer"
         ]
       }
     ],
@@ -4488,6 +4622,470 @@
       ],
       "defaultClientScopes": [
         "web-origins",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "4ebeb21b-055e-403f-8bfa-738bb935395d",
+      "clientId": "sa-cl25-cx-1",
+      "name": "BPDM Dummy Cleaning Task Processor",
+      "description": "Client for the BPDM cleaning service dummy component to process golden record tasks from the Orchestrator",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "/*"
+      ],
+      "webOrigins": [
+        "/*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "oidc.ciba.grant.enabled": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "client.secret.creation.time": "1722276592",
+        "backchannel.logout.session.required": "true",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "5386537c-2b62-4675-94aa-38f7f056a50e",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "introspection.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "eb517cbb-1f6c-4862-a230-fecf893df8bf",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "introspection.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c9d1f428-0ad8-4665-9d40-82cd4eb63109",
+          "name": "BPN",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "bpn",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "bpn",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "64f17173-6918-444d-9aa7-e97ab6f5d7e0",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "introspection.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "0dffae1b-5a95-4253-857e-b84c6904d012",
+      "clientId": "sa-cl25-cx-2",
+      "name": "BPDM Pool Task Processor",
+      "description": "Client for the BPDM Pool component to process golden record tasks from the Orchestrator",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "/*"
+      ],
+      "webOrigins": [
+        "/*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "oidc.ciba.grant.enabled": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "client.secret.creation.time": "1722276592",
+        "backchannel.logout.session.required": "true",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "33525cbd-2aae-49b9-8fda-ae2d0752ed21",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "introspection.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "061cf481-3df4-4b07-921a-fc574ca2ea75",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "introspection.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "02952ea5-5834-42d4-a16c-519448474085",
+          "name": "BPN",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "bpn",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "bpn",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "97681229-fdb3-46fa-96a6-f0a18455deeb",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "introspection.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "dfb5e903-2509-4d52-bef5-2c6a85e34d5c",
+      "clientId": "sa-cl25-cx-3",
+      "name": "BPDM Portal Gate Task Creator",
+      "description": "Client for the BPDM Portal Gate to create and monitor golden record tasks inside the Orchestrator",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "/*"
+      ],
+      "webOrigins": [
+        "/*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "oidc.ciba.grant.enabled": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "client.secret.creation.time": "1722276592",
+        "backchannel.logout.session.required": "true",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "cef30c81-427c-496b-a715-289f237a47a8",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "introspection.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "7b517bee-6230-4ab6-ad4b-21e1935ab91f",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "introspection.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "84d26429-8401-4271-a9bf-61c519b2f2d1",
+          "name": "BPN",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "bpn",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "bpn",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "43488006-09e9-4e43-9223-8a492b955c61",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "introspection.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "fd3c0f0d-40f6-4522-9a87-17ea147e7cfe",
+      "clientId": "sa-cl7-cx-1",
+      "name": "BPDM Portal Gate Pool Consumer",
+      "description": "Client for the BPDM Portal Gate to consume golden record data from the Pool",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "/*"
+      ],
+      "webOrigins": [
+        "/*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "oidc.ciba.grant.enabled": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "client.secret.creation.time": "1722276592",
+        "backchannel.logout.session.required": "true",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "a38f5a71-c7e9-47e8-966d-fb6ec3bcf382",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "introspection.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d28bf27f-b56c-4ccc-b912-f4c58f8f5d0c",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "introspection.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "9d722fd1-f545-434e-b7c9-e519b8e3519c",
+          "name": "BPN",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "bpn",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "bpn",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "cfd2e1ca-f87e-40b4-9e45-40656fd414a0",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "introspection.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
         "roles",
         "profile",
         "email"


### PR DESCRIPTION
## Description

This pull request adjusts the Central-IDP realm configuration to be more align with the BPDM default authentication configuration for the release 24.08. / BPDM version 6.1.0 as described [here](https://github.com/eclipse-tractusx/bpdm/blob/release/6.1.x/docs/arc42/arc42-bpdm.md#authentication--autorization)

- add Orchestrator client and permissions
- add Orchestrator roles
- add service accounts for Gate, Pool and Cleaning Service Dummy
- fixes some roles and permissions for the BPDM clients

All changes were tested with BPDM to setup the golden record process successfully.

## Why

Currently, the configuration between the Central-IDP and BPDM is not completely aligned. This leads to more complexity and configuration overhead for operators. Also, currently Central-IDP is missing some technical users/service accounts which is needed by an authenticated golden record process. By providing these initial service accounts an operator does not need to adapt the keycloak realm when setting up the the basic golden record process.

## Issue

#154 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/technical%20documentation/14.%20How%20to%20contribute.md)
- [x] I have added copyright and license headers, footers (for .md files) or files (for images) 
- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
