### PR TITLE
fix: extend regex for special characters and umlauts

### DIFF
--- a/import/keycloak-themes/catenax-central/login/resources/js/Main.js
+++ b/import/keycloak-themes/catenax-central/login/resources/js/Main.js
@@ -48,7 +48,7 @@ const N = (tag, c, att) => {
     return append(n, c)
 }
 const SEARCH_VALIDATION_REGEX =
-  /^[a-zA-Z0-9][a-zA-Z0-9 !#'$@&%()*+,\-_./:;=<>?[\]\\^]{0,255}$/
+  /^[a-zA-ZÀ-ÿŚął\d][a-zA-ZÀ-ÿŚął\d !#'$@&%()*+,\-_./:;=<>?[\]\\^]{0,255}$/;
 
 const remove = (n) => n.parentElement.removeChild(n)
 

--- a/import/keycloak-themes/catenax-central/login/resources/js/Main.js
+++ b/import/keycloak-themes/catenax-central/login/resources/js/Main.js
@@ -48,7 +48,7 @@ const N = (tag, c, att) => {
     return append(n, c)
 }
 const SEARCH_VALIDATION_REGEX =
-  /^[a-zA-ZÀ-ÿŚął\d][a-zA-ZÀ-ÿŚął\d !#'$@&%()*+,\-_./:;=<>?[\]\\^]{0,255}$/;
+  /^[a-zA-Z0-9][a-zA-Z0-9 !#'$@&%()*+,\-_./:;=<>?[\]\\^]{0,255}$/
 
 const remove = (n) => n.parentElement.removeChild(n)
 


### PR DESCRIPTION
## Description

- Update central search field regex validation code to allow special characters and umlauts

## Why

Companies that contained special characters or umlauts were not searchable via the search field. 

## Issue

#164 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/technical%20documentation/14.%20How%20to%20contribute.md)
- [ ] I have added copyright and license headers, footers (for .md files) or files (for images) 
- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [ ] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [ ] I have commented my changes, particularly in hard-to-understand areas
