### PR TITLE
feat(notification): adjust create notification role

### DIFF
--- a/docs/technical documentation/06. Roles & Rights Concept.md
+++ b/docs/technical documentation/06. Roles & Rights Concept.md
@@ -218,7 +218,7 @@ Legend:
 | View offered app details (app_management) | x | | | | | | x | |
 | Access technical user details (view_tech_user_management) | x | | | | | | | x |
 | send_mail | | | | | | | | |
-| create_notifications | | | | | | | | |
+| create_ssi_notifications | | | | | | | | |
 |update_application_bpn_credential | | | | | | | | |
 |update_application_membership_credential | | | | | | | | |
 | **BPN Discovery (Cl22-CX-BPND)** | | | | | | | | |

--- a/import/realm-config/generic/catenax-central/CX-Central-realm.json
+++ b/import/realm-config/generic/catenax-central/CX-Central-realm.json
@@ -1346,7 +1346,7 @@
                 "add_service_offering",
                 "view_notifications",
                 "view_certificates",
-                "create_notifications",
+                "create_ssi_notifications",
                 "unsubscribe_services",
                 "modify_connectors",
                 "view_use_case_participation",
@@ -1431,8 +1431,8 @@
         },
         {
           "id": "22b05ced-cd8e-4769-a368-b8266bf967ef",
-          "name": "create_notifications",
-          "description": "User can create notifications (ONLY FOR TEST REASONS)",
+          "name": "create_ssi_notifications",
+          "description": "User can create notifications for ssi credentials",
           "composite": false,
           "clientRole": true,
           "containerId": "e0806293-f9b3-44f1-a6d0-4e4406787f80",
@@ -2891,7 +2891,6 @@
       "clientRoles": {
         "Cl2-CX-Portal": [
           "update_application_bpn_credential",
-          "create_notifications",
           "send_mail",
           "update_application_membership_credential"
         ]
@@ -3168,7 +3167,7 @@
         "client": "sa-cl24-01",
         "roles": [
           "send_mail",
-          "create_notifications",
+          "create_ssi_notifications",
           "update_application_membership_credential",
           "update_application_bpn_credential"
         ]


### PR DESCRIPTION
## Description

Adjust the create notification role to be specific for its use case

## Why

The create_notifications role was to generic and is only used for the ssi related notifications

## Issue

Refs: [#812](https://github.com/eclipse-tractusx/portal-backend/issues/812)

## Corresponding Backend PR

https://github.com/eclipse-tractusx/portal-backend/pull/906

## Corresponding SSI PR

https://github.com/eclipse-tractusx/ssi-credential-issuer/pull/233

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/technical%20documentation/14.%20How%20to%20contribute.md)
- [x] I have added copyright and license headers, footers (for .md files) or files (for images) 
- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
