### PR TITLE
feat(roles): add subscribe_service permission to Business Admin

### DIFF
--- a/import/realm-config/generic/catenax-central/CX-Central-realm.json
+++ b/import/realm-config/generic/catenax-central/CX-Central-realm.json
@@ -433,6 +433,7 @@
                 "view_own_user_account",
                 "view_user_management",
                 "subscribe_apps",
+                "subscribe_service",
                 "view_membership",
                 "update_own_user_account",
                 "request_ssicredential",


### PR DESCRIPTION
## Description

Add `subscribe_service` to Business Admin composite role. As defined by [permission matrix](https://github.com/eclipse-tractusx/portal-assets/blob/v2.1.0/public/assets/images/content/PortalRoleAndPermissionMatrix.png).

## Why

This missing permission prevented Business Admin from subscribing to services.

## Issue

Refs: eclipse-tractusx/portal-iam#172

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/technical%20documentation/14.%20How%20to%20contribute.md)
- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes

