### PR TITLE
chore: add view_idp to business admin

### DIFF
--- a/docs/technical documentation/06. Roles & Rights Concept.md
+++ b/docs/technical documentation/06. Roles & Rights Concept.md
@@ -117,10 +117,10 @@ Legend:
 | Delete Documents (delete_documents) | x | x | | | | | x | | x | | |
 | **User Management** | | | | | | | | | | | |
 | Access User Management (view_user_management) | x | x | x | x | x | x | x | x | x | x | |
-| Add a new user (add_user_account) | x | x | x | x | | | | | | | |
+| Add a new user (add_user_account) | x | x | | x | | | | | | | |
 | Delete a user of the same org. (delete_user_account) | x | x | | x | | | | | | | |
-| Modify a user of the same org. (modify_user_account) | x | x | x | x | | | | | | | |
-| View Offer Roles - apps as well as core offers. Needed for users which can change role assignment and create user accounts (view_client_roles) | x | x | x | x | | | | | | | |
+| Modify a user of the same org. (modify_user_account) | x | x | | x | | | | | | | |
+| View Offer Roles - apps as well as core offers. Needed for users which can change role assignment and create user accounts (view_client_roles) | x | x | | x | | | | | | | |
 | View own user account details (view_own_user_account) | x | x | x | x | x | x | x | x | x | x | |
 | Modify my user account (update_own_user_account) | x | x | x | x | x | x | x | x | x | x | |
 | Delete my user account (delete_own_user_account) | x | x | x | x | x | x | x | x | x | x | |

--- a/docs/technical documentation/06. Roles & Rights Concept.md
+++ b/docs/technical documentation/06. Roles & Rights Concept.md
@@ -117,10 +117,10 @@ Legend:
 | Delete Documents (delete_documents) | x | x | | | | | x | | x | | |
 | **User Management** | | | | | | | | | | | |
 | Access User Management (view_user_management) | x | x | x | x | x | x | x | x | x | x | |
-| Add a new user (add_user_account) | x | x | | x | | | | | | | |
+| Add a new user (add_user_account) | x | x | x | x | | | | | | | |
 | Delete a user of the same org. (delete_user_account) | x | x | | x | | | | | | | |
-| Modify a user of the same org. (modify_user_account) | x | x | | x | | | | | | | |
-| View Offer Roles - apps as well as core offers. Needed for users which can change role assignment and create user accounts (view_client_roles) | x | x | | x | | | | | | | |
+| Modify a user of the same org. (modify_user_account) | x | x | x | x | | | | | | | |
+| View Offer Roles - apps as well as core offers. Needed for users which can change role assignment and create user accounts (view_client_roles) | x | x | x | x | | | | | | | |
 | View own user account details (view_own_user_account) | x | x | x | x | x | x | x | x | x | x | |
 | Modify my user account (update_own_user_account) | x | x | x | x | x | x | x | x | x | x | |
 | Delete my user account (delete_own_user_account) | x | x | x | x | x | x | x | x | x | x | |
@@ -130,7 +130,7 @@ Legend:
 | Delete Technical User (delete_tech_user_management) | x | x | | x | | | | | | x | |
 | **Technical Management** | | | | | | | | | | | |
 | View Technical Integration on the UI - no backend permission (view_technical_setup) - **obsolete** | x | x |  | x | | | x | x | | x | |
-| View IdP Details (view_idp) | x | x | | x | | | | | x | | |
+| View IdP Details (view_idp) | x | x | x | x | | | | | x | | |
 | View Managed IdP Details (view_managed_idp) | x | x | | x | | | | | | x | |
 | Create a new IdP record (add_idp) | x | x | | x | | | | | | x | |
 | Update IdP Config (setup_idp) | x | x | | x | | | | | | x | |

--- a/import/realm-config/generic/catenax-central/CX-Central-realm.json
+++ b/import/realm-config/generic/catenax-central/CX-Central-realm.json
@@ -422,8 +422,10 @@
               "Cl2-CX-Portal": [
                 "view_documents",
                 "view_app_subscription",
+                "add_user_account",
                 "view_company_data",
                 "view_service_marketplace",
+                "modify_user_account",
                 "view_service_offering",
                 "view_autosetup_status",
                 "unsubscribe_apps",
@@ -438,13 +440,15 @@
                 "view_notifications",
                 "view_certificates",
                 "delete_certificates",
+                "view_client_roles",
                 "delete_own_user_account",
                 "unsubscribe_services",
                 "view_apps",
                 "view_subscription",
                 "view_use_case_participation",
                 "delete_notifications",
-                "view_partner_network"
+                "view_partner_network",
+                "view_idp"
               ],
               "Cl3-CX-Semantic": [
                 "add_semantic_model",

--- a/import/realm-config/generic/catenax-central/CX-Central-realm.json
+++ b/import/realm-config/generic/catenax-central/CX-Central-realm.json
@@ -422,10 +422,8 @@
               "Cl2-CX-Portal": [
                 "view_documents",
                 "view_app_subscription",
-                "add_user_account",
                 "view_company_data",
                 "view_service_marketplace",
-                "modify_user_account",
                 "view_service_offering",
                 "view_autosetup_status",
                 "unsubscribe_apps",
@@ -440,7 +438,6 @@
                 "view_notifications",
                 "view_certificates",
                 "delete_certificates",
-                "view_client_roles",
                 "delete_own_user_account",
                 "unsubscribe_services",
                 "view_apps",


### PR DESCRIPTION
## Description

Add the role: `view_idp` to the `Business Admin` role

## Why

The business admin has to many rights

## Issue

Refs: #178

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/technical%20documentation/14.%20How%20to%20contribute.md)
- [x] I have added copyright and license headers, footers (for .md files) or files (for images) 
- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
