### PR TITLE
feat(tech user): add new operator invite tech user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 New features, fixed bugs, known defects and other noteworthy changes to each release of the Catena-X IAM * Keycloak instances.
 
+## Unreleased
+
+### Change
+
+* created the following composite roles inside the `technical_roles_management` client:
+  * `Registration Internal` [#189](https://github.com/eclipse-tractusx/portal-iam/pull/189)
+     * With `Cl2-CX-Portal` roles:
+       * invite_new_partner
+       * view_submitted_applications 
+
 ## 3.0.1
 
 ### Change

--- a/import/realm-config/generic/catenax-central/CX-Central-realm.json
+++ b/import/realm-config/generic/catenax-central/CX-Central-realm.json
@@ -1872,6 +1872,23 @@
           "clientRole": true,
           "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
           "attributes": {}
+        },
+        {
+          "id": "884698bc-bb74-4661-a90f-3ba214b74593",
+          "name": "Registration Internal",
+          "description": "Technical user enabling the invitation API to integrate 3rd party software.",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl2-CX-Portal": [
+                "invite_new_partner",
+                "view_submitted_applications"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "6df310ed-500e-43d5-b510-fa4668e939ee",
+          "attributes": {}
         }
       ],
       "admin-cli": [],


### PR DESCRIPTION
## Description

New `technical_roles_management` composite role with name `Registration Internal` with:
- `invite_new_partner`
- `view_submitted_applications`

Both were previously only available for CX Admin.

Backend change: eclipse-tractusx/portal-backend#1002

## Why

Operator company wants to integrate 3rd party service to send out invites. Allows inviting and reviewing status via API.

## Issue

Refs: eclipse-tractusx/portal-backend#932

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/technical%20documentation/14.%20How%20to%20contribute.md)
- [ ] I have added copyright and license headers, footers (for .md files) or files (for images) 
- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [ ] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [ ] I have commented my changes, particularly in hard-to-understand areas
