### PR TITLE
feat: Add centralIdp configuration for stable environment

### DIFF
--- a/environments/helm-values/centralidp/values-stable.yaml
+++ b/environments/helm-values/centralidp/values-stable.yaml
@@ -1,0 +1,48 @@
+###############################################################
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+keycloak:
+  production: true
+  proxy: edge
+  ingress:
+    enabled: true
+    ingressClassName: nginx
+    hostname: centralidp.stable.catena-x.net
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+      nginx.ingress.kubernetes.io/cors-allow-methods: PUT, GET, POST, OPTIONS
+      nginx.ingress.kubernetes.io/cors-allow-origin: https://centralidp.stable.catena-x.net
+      nginx.ingress.kubernetes.io/enable-cors: "true"
+      nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+      nginx.ingress.kubernetes.io/proxy-buffering: "on"
+      nginx.ingress.kubernetes.io/proxy-buffers-number: "20"
+      nginx.ingress.kubernetes.io/use-regex: "true"
+    tls: true
+
+secrets:
+  auth:
+    existingSecret:
+      adminpassword: "<path:portal/data/stable/iam/centralidp-keycloak#admin-password>"
+  postgresql:
+    auth:
+      existingSecret:
+        postgrespassword: "<path:portal/data/stable/iam/centralidp-keycloak#postgres-admin-user>"
+        password: "<path:portal/data/stable/iam/centralidp-keycloak#postgres-custom-user>"
+        replicationPassword: "<path:portal/data/stable/iam/centralidp-keycloak#postgres-replication-user>"


### PR DESCRIPTION
## Description

This PR will introduce environment specific configuration for the 24.08 centraldIdp release to run on the catena-x stable environment.

## Issue

relates to https://github.com/eclipse-tractusx/portal/issues/408

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/technical%20documentation/14.%20How%20to%20contribute.md)
- [x] I have added copyright and license headers, footers (for .md files) or files (for images) 
- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
