### PR TITLE
chore(centralidp): increase memory for realm seeding

### DIFF
--- a/charts/centralidp/values.yaml
+++ b/charts/centralidp/values.yaml
@@ -243,9 +243,9 @@ realmSeeding:
   resources:
     requests:
       cpu: 250m
-      memory: 600M
+      memory: 700M
       ephemeral-storage: 50Mi
     limits:
       cpu: 750m
-      memory: 600M
+      memory: 700M
       ephemeral-storage: 1024Mi


### PR DESCRIPTION
## Description

increase memory for realm seeding

## Why

observed OOM kill when testing seeding of extra service accounts

## Issue

#86

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/technical%20documentation/14.%20How%20to%20contribute.md) 
- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
