### PR TITLE
fix: increase memory for realm seeding job

### DIFF
--- a/charts/centralidp/values.yaml
+++ b/charts/centralidp/values.yaml
@@ -239,9 +239,9 @@ realmSeeding:
   resources:
     requests:
       cpu: 250m
-      memory: 700M
+      memory: 850M
       ephemeral-storage: 50Mi
     limits:
       cpu: 750m
-      memory: 700M
+      memory: 850M
       ephemeral-storage: 1024Mi

--- a/charts/sharedidp/values.yaml
+++ b/charts/sharedidp/values.yaml
@@ -194,9 +194,9 @@ realmSeeding:
   resources:
     requests:
       cpu: 250m
-      memory: 600M
+      memory: 700M
       ephemeral-storage: 50Mi
     limits:
       cpu: 750m
-      memory: 600M
+      memory: 700M
       ephemeral-storage: 1024Mi


### PR DESCRIPTION
## Description

increase memory for realm seeding job

## Why

install on int env showed OOM kills

## Issue

#86 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/technical%20documentation/14.%20How%20to%20contribute.md)
- [x] I have successfully tested my changes
