### PR TITLE
chore: exclude .yaml file inside docs folder in sonarcloud analysis

### DIFF
--- a/.sonarcloud copy.properties
+++ b/.sonarcloud copy.properties
@@ -1,1 +1,0 @@
-sonar.exclusions = docs/**/*.yaml

--- a/.sonarcloud copy.properties
+++ b/.sonarcloud copy.properties
@@ -1,0 +1,1 @@
+sonar.exclusions = docs/**/*.yaml

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,2 @@
 sonar.cpd.exclusions = import/keycloak-themes/**/*.*
+sonar.exclusions = docs/**/*.yaml


### PR DESCRIPTION
## Description

Add sonarcloud.properties file to exclude all .yaml files within the docs folder and subdirectories.

## Why

This change prevents non-code files from affecting the SonarCloud quality gate checks.

## Issue

Fix sonar error in following issue - #187 

## Checklist

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/technical%20documentation/14.%20How%20to%20contribute.md)
- [X] I have performed a self-review of my changes