### PR TITLE
feat(decline_subscription): Permission created in in the Client `Cl2-CX-Portal`

### DIFF
--- a/import/realm-config/generic/catenax-central/CX-Central-realm.json
+++ b/import/realm-config/generic/catenax-central/CX-Central-realm.json
@@ -310,6 +310,7 @@
                 "delete_connectors",
                 "add_connectors",
                 "activate_subscription",
+                "decline_subscription",
                 "view_service_marketplace",
                 "update_own_user_account",
                 "view_service_offering",
@@ -697,6 +698,15 @@
           "attributes": {}
         },
         {
+          "id": "f8d81c07-fa16-4e84-9ad9-29f8d9dedbc3",
+          "name": "decline_subscription",
+          "description": "Declination of subscriptions",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "5d09a280-1a45-4519-a086-c0f5d49e4ed8",
+          "attributes": {}
+        },
+        {
           "id": "3cc2dbf1-3072-470b-92b1-49ef33ac0dd7",
           "name": "Company Admin",
           "composite": true,
@@ -912,6 +922,7 @@
                 "edit_apps",
                 "view_certificates",
                 "activate_subscription",
+                "decline_subscription",
                 "view_app_subscription",
                 "App Developer",
                 "view_autosetup_status"
@@ -1208,6 +1219,7 @@
                 "add_connectors",
                 "modify_user_account",
                 "activate_subscription",
+                "decline_subscription",
                 "update_own_user_account",
                 "update_service_offering",
                 "delete_notifications",
@@ -1456,6 +1468,7 @@
                 "view_service_subscriptions",
                 "view_certificates",
                 "activate_subscription",
+                "decline_subscription",
                 "subscribe_service",
                 "view_service_offering",
                 "view_app_subscription",
@@ -1659,6 +1672,7 @@
               "Cl2-CX-Portal": [
                 "view_tech_user_management",
                 "activate_subscription",
+                "decline_subscription",
                 "app_management",
                 "add_service_offering",
                 "add_connectors"


### PR DESCRIPTION
## Description

Permission created in in the Client `Cl2-CX-Portal`

## Why

To enable a new [backend api](https://github.com/eclipse-tractusx/portal-backend/issues/1140), we need to implement a new permission called `decline_subscription` in the Client `Cl2-CX-Portal`

## Issue

Ref: #232

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [ ] I have added copyright and license headers, footers (for .md files) or files (for images) 
- [x] I have performed a self-review of my changes
- [ ] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
