### PR TITLE
Feat(BPDM): Add Pool Use Case Consumer Role

### DIFF
--- a/docs/admin/technical-documentation/06. Roles & Rights Concept.md
+++ b/docs/admin/technical-documentation/06. Roles & Rights Concept.md
@@ -284,16 +284,22 @@ Managed via Client: **Cl7-CX-BPDM**
 | read_metadata                    | x             | x                   |                   |                              |                              |                              |                              |                              |                              |                              |                              | x                                 |
 | read_partner                     | x             | x                   |                   |                              |                              |                              |                              |                              |                              |                              |                              |                                   |
 | read_partner_member              | x             | x                   | x                 |                              |                              |                              |                              |                              |                              |                              |                              |                                   |
+| read_partner_member_owned        | x             | x                   |                   |                              |                              |                              |                              |                              |                              |                              |                              |                                   |
 | write_metadata                   | x             | x                   |  x                | x                            | x                            | x                            | x                            | x                            | x                            | x                            | x                            | x                                 |
 | write_partner                    | x             | x                   |                   |                              |                              |                              |                              |                              |                              |                              |                              |                                   |
 
-Technical Users*: BPDM Admin, BPDM Pool Consumer & BPDM Pool Sharing Consumer.
+
+Technical Users*: BPDM Admin, BPDM Pool Consumer, BPDM Pool Use Case Consumer, & BPDM Pool Sharing Consumer.
 
 Following the permission assignment
 
 - BPDM Pool Consumer
   - read_partner_member
   - read_changelog_member
+  - read_metadata
+
+- BPDM Pool Use Case Consumer
+  - read_partner_member_owned
   - read_metadata
   
 - BPDM Pool Sharing Consumer

--- a/import/realm-config/generic/catenax-central/CX-Central-realm.json
+++ b/import/realm-config/generic/catenax-central/CX-Central-realm.json
@@ -1130,7 +1130,8 @@
                 "read_changelog",
                 "read_partner_member",
                 "read_metadata",
-                "read_changelog_member"
+                "read_changelog_member",
+                "read_partner_member_owned"
               ],
               "Cl5-CX-Custodian": [
                 "add_wallet",
@@ -1607,6 +1608,15 @@
           "clientRole": true,
           "containerId": "2ef350bf-f017-4696-9f97-e01db49341d2",
           "attributes": {}
+        },
+        {
+          "id": "426a1cf1-46a0-484e-b2d6-436bb23a5df8",
+          "name": "read_partner_member_owned",
+          "description": "Allow read access to all business partners that are owned by Catena-X members",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2ef350bf-f017-4696-9f97-e01db49341d2",
+          "attributes": {}
         }
       ],
       "technical_roles_management": [
@@ -1683,7 +1693,8 @@
                 "read_partner_member",
                 "write_metadata",
                 "read_changelog_member",
-                "read_metadata"
+                "read_metadata",
+                "read_partner_member_owned"
               ]
             }
           },
@@ -1755,6 +1766,23 @@
               "Cl7-CX-BPDM": [
                 "read_changelog",
                 "read_partner",
+                "read_metadata"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
+          "attributes": {}
+        },
+        {
+          "id": "f024abdd-a80e-49bf-8add-e7a45fb609a4",
+          "name": "BPDM Pool Use Case Consumer",
+          "description": "Role for Catena-X use case providers needing access to extended Cx member data",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl7-CX-BPDM": [
+                "read_partner_member_owned",
                 "read_metadata"
               ]
             }


### PR DESCRIPTION


## Description

This pull request adds a new technical user role to the BPDM authorization scope: `BPDM Pool Use Case Consumer Role`. This role is used for use cases needing access to Cx members and their subsidiaries Pool data.

## Why

The BPDM Pool needs to be accessible by a new user group which should receive unique access rights to the Pool business partner data.

## Issue

Relates to issue https://github.com/eclipse-tractusx/bpdm/issues/1088

Relevant ongoing BPDM contribution: https://github.com/eclipse-tractusx/bpdm/pull/1144

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [ ] I have added copyright and license headers, footers (for .md files) or files (for images) 
- [ ] I have performed a self-review of my changes
- [ ] I have successfully tested my changes
- [ ] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [ ] I have commented my changes, particularly in hard-to-understand areas
