### PR TITLE
fix(realm-seeding): add faster version of job

### DIFF
--- a/charts/centralidp/values.yaml
+++ b/charts/centralidp/values.yaml
@@ -227,7 +227,7 @@ realmSeeding:
     # -- Option to provide an existingSecret for additional service accounts with clientId as key and clientSecret as value.
     existingSecret: ""
   image:
-    name: docker.io/tractusx/portal-iam-seeding:v4.0.0-iam
+    name: docker.io/tractusx/portal-iam-seeding:v4.0.1-iam
     pullPolicy: IfNotPresent
   initContainer:
     image:

--- a/charts/sharedidp/values.yaml
+++ b/charts/sharedidp/values.yaml
@@ -182,7 +182,7 @@ realmSeeding:
       # -- Option to provide an existingSecret for clients secrets with clientId as key and clientSecret as value.
       existingSecret: ""
   image:
-    name: docker.io/tractusx/portal-iam-seeding:v4.0.0-iam
+    name: docker.io/tractusx/portal-iam-seeding:v4.0.1-iam
     pullPolicy: IfNotPresent
   initContainer:
     image:


### PR DESCRIPTION
## Description

add faster version of realm seeding job

## Why

Depending on the size of the seeded realm the [seeding job](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/admin/technical-documentation/14.%20Realm%20Seeding.md) takes quite long to complete.

## Issue

https://github.com/eclipse-tractusx/portal-iam/issues/238

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
