### PR TITLE
feat(cx-central realm): Add Connector Management composite role in the central idp

### DIFF
--- a/docs/admin/technical-documentation/06. Roles & Rights Concept.md
+++ b/docs/admin/technical-documentation/06. Roles & Rights Concept.md
@@ -216,40 +216,44 @@ This role concept covers all roles related to
 
 #### 2.5.3b Technical User Accounts
 
-| | **Offer Management** | BPDM Management | BPDM Partner Gate | **Identity Wallet Management** | **Dataspace Discovery** | **Semantic Model Management** | **CX Membership Info** | **External Registration** |
-|-|----------------------------------------|-----------------|-------------------|----------------------------|---------------------|---------------------------|--------------------|-----------------------|
-| **Semantic App (Cl3-CX-Semantic)** | | | | | | | | |
-| View Semantic Models (view_semantic_model) | | | | | | x | | |
-| Add Semantic Models (add_semantic_model) | | | | | | | | |
-| Update Semantic Models (update_semantic_model) | | | | | | | | |
-| Delete Semantic Models (delete_semantic_model) | | | | | | | | |
-| **Wallet App (Cl5-CX-Custodian)** | | | | | | | | |
-| Create new wallet (add_wallet) - exclusively for the platform operator | | | | | | | | |
-| View wallet (view_wallet) **interim obsolete** | | | | x | | | | |
-| Update own wallet (update_wallet) **interim obsolete** | | | | x | | | | |
-| **Portal App (Cl2-CX-Portal)** | | | | | | | | |
-| View connectors of BP (view_connectors) | | | | | x | | | |
-| Customer Subscription Activation (activate_subscription) | x | | | | | | | |
-| Customer Subscription Declination (decline_subscription) | x | | | | | | | |
-| Register new connector (add_connectors) | x | | | | | | | |
-| Create new service offering (add_service_offering) | x | | | | | | | |
-| View Membership (view_membership) | | | | | | | x | |
-| Create 3rd party registrations/Configure OSP Callback Url (configure_partner_registration) | | | | | | | | x |
-| View offered app details (app_management) | x | | | | | | x | |
-| Access technical user details (view_tech_user_management) | x | | | | | | | x |
-| send_mail | | | | | | | | |
-| create_ssi_notifications | | | | | | | | |
-| store_didDocument | | | | | | | | |
-| update_application_bpn_credential | | | | | | | | |
-| update_application_membership_credential | | | | | | | | |
-| **BPN Discovery (Cl22-CX-BPND)** | | | | | | | | |
-| View Discovery BPN (view_bpn_discovery) | | | | | x | | | |
-| Add Discovery BPN (add_bpn_discovery) | | | | | x | | | |
-| Delete Discovery BPN (delete_bpn_discovery) | | | | | x | | | |
-| **Discovery Finder (Cl21-CX-DF)** | | | | | | | | |
-| View Discovery Finders (view_discovery_endpoint) | | | | | x | | | |
-| Add Discovery Finders (add_discovery_endpoint) - exclusively for the platform operator | | | | | | | | |
-| Delete Discovery Finders (delete_discovery_endpoint) - exclusively for the platform operator | | | | | | | | |
+| | **Offer Management** | BPDM Management | BPDM Partner Gate | **Identity Wallet Management** | **Dataspace Discovery** | **Semantic Model Management** | **CX Membership Info** | **External Registration** | **Connector Management** |
+|-|------------------------|------------------|-------------------|-------------------------------|--------------------------|-------------------------------|-------------------------|----------------------------|---------------------------|
+| **Semantic App (Cl3-CX-Semantic)** | | | | | | | | | |
+| View Semantic Models (view_semantic_model) | | | | | | x | | | |
+| Add Semantic Models (add_semantic_model) | | | | | | | | | |
+| Update Semantic Models (update_semantic_model) | | | | | | | | | |
+| Delete Semantic Models (delete_semantic_model) | | | | | | | | | |
+| **Wallet App (Cl5-CX-Custodian)** | | | | | | | | | |
+| Create new wallet (add_wallet) - exclusively for the platform operator | | | | | | | | | |
+| View wallet (view_wallet) **interim obsolete** | | | | x | | | | | |
+| Update own wallet (update_wallet) **interim obsolete** | | | | x | | | | | |
+| **Portal App (Cl2-CX-Portal)** | | | | | | | | | |
+| View connectors of BP (view_connectors) | | | | | x | | | | x |
+| Customer Subscription Activation (activate_subscription) | x | | | | | | | | |
+| Customer Subscription Declination (decline_subscription) | x | | | | | | | | |
+| Register new connector (add_connectors) | x | | | | | | | | x |
+| Modify Connectors (modify_connectors) | | | | | | | | | x |
+| Delete Connectors (delete_connectors) | | | | | | | | | x |
+| Create new service offering (add_service_offering) | x | | | | | | | | |
+| View Membership (view_membership) | | | | | | | x | | |
+| Create 3rd party registrations/Configure OSP Callback Url (configure_partner_registration) | | | | | | | | x | |
+| View offered app details (app_management) | x | | | | | | x | | |
+| Access technical user details (view_tech_user_management) | x | | | | | | | x | x |
+| Add Technical user management (add_tech_user_management) | | | | | | | | | x |
+| **Miscellaneous** | | | | | | | | | |
+| send_mail | | | | | | | | | |
+| create_ssi_notifications | | | | | | | | | |
+| store_didDocument | | | | | | | | | |
+| update_application_bpn_credential | | | | | | | | | |
+| update_application_membership_credential | | | | | | | | | |
+| **BPN Discovery (Cl22-CX-BPND)** | | | | | | | | | |
+| View Discovery BPN (view_bpn_discovery) | | | | | x | | | | |
+| Add Discovery BPN (add_bpn_discovery) | | | | | x | | | | |
+| Delete Discovery BPN (delete_bpn_discovery) | | | | | x | | | | |
+| **Discovery Finder (Cl21-CX-DF)** | | | | | | | | | |
+| View Discovery Finders (view_discovery_endpoint) | | | | | x | | | | |
+| Add Discovery Finders (add_discovery_endpoint) - exclusively for the platform operator | | | | | | | | | |
+| Delete Discovery Finders (delete_discovery_endpoint) - exclusively for the platform operator | | | | | | | | | |
 
 #### 2.5.4 Managed Wallets
 

--- a/import/realm-config/generic/catenax-central/CX-Central-realm.json
+++ b/import/realm-config/generic/catenax-central/CX-Central-realm.json
@@ -1975,6 +1975,28 @@
           "clientRole": true,
           "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
           "attributes": {}
+        },
+        {
+          "id": "9f8c4c27-2a5e-4d5c-9a6b-8e7d4c0e7b3a",
+          "name": "Connector Management",
+          "description": "Allowed to access connector registration features without using UI",
+          "composite": true,
+          "composites": {
+            "client": {
+              "Cl2-CX-Portal": [
+                  "view_tech_user_management",
+                  "add_tech_user_management",
+                  "technical_roles_management",
+                  "view_connectors",
+                  "add_connectors",
+                  "modify_connectors",
+                  "delete_connectors"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "114605ea-9c64-4dff-9bc7-90fe02a004c3",
+          "attributes": {}
         }
       ],
       "admin-cli": [],


### PR DESCRIPTION
## Description

* Added `Connector Management` composite role in the cx-central realm in the central idp

## Why

As portal user, I want to create `Connector Management` technical user, so that I can access connector registration features without using UI.

## Issue

#271 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my changes
- [ ] I have successfully tested my changes
