### PR TITLE
fix: add missing view_app_subscripton role to offer management role composite

### DIFF
--- a/docs/admin/technical-documentation/06. Roles & Rights Concept.md
+++ b/docs/admin/technical-documentation/06. Roles & Rights Concept.md
@@ -231,6 +231,7 @@ This role concept covers all roles related to
 | View connectors of BP (view_connectors) | | | | | x | | | | x |
 | Customer Subscription Activation (activate_subscription) | x | | | | | | | | |
 | Customer View Subscriptions (view_subscription) | x | | | | | | | |
+| Gets an overview of subscriptions active, inactive, pending (view_app_subscription) | x | | | | | | | |
 | Customer Subscription Declination (decline_subscription) | x | | | | | | | | |
 | Register new connector (add_connectors) | x | | | | | | | | x |
 | Modify Connectors (modify_connectors) | | | | | | | | | x |

--- a/import/realm-config/generic/catenax-central/CX-Central-realm.json
+++ b/import/realm-config/generic/catenax-central/CX-Central-realm.json
@@ -1675,7 +1675,8 @@
                 "app_management",
                 "add_service_offering",
                 "add_connectors",
-                "view_subscription"
+                "view_subscription",
+                "view_app_subscription"
               ]
             }
           },


### PR DESCRIPTION
## Description

Assigned the view_app_subscription role to Offer Management

## Why

In order to allow all users to have access to endpoints that requires view_app_subscription role. i.e: /api/Apps/provided/subscription-status.

On the documentation [06. Roles & Rights Concept.md](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/admin/technical-documentation/06.%20Roles%20%26%20Rights%20Concept.md), this role is presented on the description:

![image](https://github.com/user-attachments/assets/23e7d4dd-9bbe-4569-90a0-c983e1eecb5d)

## Issue

["Offer Management" Technical User Cannot Access Subscription Status Endpoint](https://github.com/eclipse-tractusx/portal-iam/issues/280)

## Checklist

Please delete options that are not relevant.

- [x] I have added copyright and license headers, footers (for .md files) or files (for images) 
- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
