### PR TITLE
build(4.2.0-rc.1): fix centralidp bump version

### DIFF
--- a/charts/centralidp/Chart.yaml
+++ b/charts/centralidp/Chart.yaml
@@ -20,7 +20,7 @@
 apiVersion: v2
 name: centralidp
 type: application
-version: v4.2.0-rc.1
+version: 4.2.0-rc.1
 appVersion: 25.0.6
 description: Helm chart for Central Keycloak Instance
 home: https://github.com/eclipse-tractusx/portal-iam


### PR DESCRIPTION
## Description

Fix chart version for centralidp 4.2.0-rc.1

## Why

Release candidate for 25.06.

## Issue

https://github.com/eclipse-tractusx/portal/issues/541

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-iam/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my changes