### PR TITLE
build(4.2.1-rc.1): change bitnami image repository and bump version

### DIFF
--- a/charts/centralidp/Chart.yaml
+++ b/charts/centralidp/Chart.yaml
@@ -20,7 +20,7 @@
 apiVersion: v2
 name: centralidp
 type: application
-version: 4.2.0
+version: 4.2.1-rc.1
 appVersion: 25.0.6
 description: Helm chart for Central Keycloak Instance
 home: https://github.com/eclipse-tractusx/portal-iam

--- a/charts/centralidp/README.md
+++ b/charts/centralidp/README.md
@@ -1,6 +1,6 @@
 # Helm chart for Central Keycloak Instance
 
-![Version: 4.2.0](https://img.shields.io/badge/Version-4.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.0.6](https://img.shields.io/badge/AppVersion-25.0.6-informational?style=flat-square)
+![Version: 4.2.1-rc.1](https://img.shields.io/badge/Version-4.2.1--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.0.6](https://img.shields.io/badge/AppVersion-25.0.6-informational?style=flat-square)
 
 This helm chart installs the Helm chart for Central Keycloak Instance.
 
@@ -29,7 +29,7 @@ To use the helm chart as a dependency:
 dependencies:
   - name: centralidp
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 4.2.0
+    version: 4.2.1-rc.1
 ```
 
 ## Requirements
@@ -42,6 +42,9 @@ dependencies:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| keycloak.image.registry | string | `"docker.io"` |  |
+| keycloak.image.repository | string | `"bitnamilegacy/keycloak"` |  |
+| keycloak.image.tag | string | `"25.0.6-debian-12-r0"` |  |
 | keycloak.auth.adminUser | string | `"admin"` |  |
 | keycloak.auth.adminPassword | string | `""` | centralidp Keycloak administrator password. |
 | keycloak.auth.existingSecret | string | `""` | Secret containing the password for admin username 'admin'. |
@@ -72,7 +75,7 @@ dependencies:
 | keycloak.rbac.rules[0].verbs[0] | string | `"get"` |  |
 | keycloak.rbac.rules[0].verbs[1] | string | `"list"` |  |
 | keycloak.postgresql.enabled | bool | `true` | PostgreSQL chart configuration (recommended for demonstration purposes only); default configurations: host: "centralidp-postgresql", port: 5432; Switch to enable or disable the PostgreSQL helm chart. |
-| keycloak.postgresql.image | object | `{"tag":"15-debian-11"}` | Setting to Postgres version 15 as that is the aligned version, https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-07/#aligning-dependency-versions). Keycloak helm-chart from Bitnami has moved on to version 16. |
+| keycloak.postgresql.image | object | `{"registry":"docker.io","repository":"bitnamilegacy/postgresql","tag":"15-debian-11"}` | Setting to Postgres version 15 as that is the aligned version, https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-07/#aligning-dependency-versions). Keycloak helm-chart from Bitnami has moved on to version 16. |
 | keycloak.postgresql.commonLabels."app.kubernetes.io/version" | string | `"15"` |  |
 | keycloak.postgresql.auth.username | string | `"kccentral"` | Non-root username. |
 | keycloak.postgresql.auth.password | string | `""` | Non-root user password. |

--- a/charts/centralidp/values.yaml
+++ b/charts/centralidp/values.yaml
@@ -18,6 +18,10 @@
 ###############################################################
 
 keycloak:
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/keycloak
+    tag: 25.0.6-debian-12-r0
   auth:
     adminUser: admin
     # -- centralidp Keycloak administrator password.
@@ -95,6 +99,8 @@ keycloak:
     # https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-07/#aligning-dependency-versions).
     # Keycloak helm-chart from Bitnami has moved on to version 16.
     image:
+      registry: docker.io
+      repository: bitnamilegacy/postgresql
       tag: 15-debian-11
     commonLabels:
       app.kubernetes.io/version: "15"

--- a/charts/sharedidp/Chart.yaml
+++ b/charts/sharedidp/Chart.yaml
@@ -20,7 +20,7 @@
 apiVersion: v2
 name: sharedidp
 type: application
-version: 4.2.0
+version: 4.2.1-rc.1
 appVersion: 25.0.6
 description: Helm chart for Shared Keycloak Instance
 home: https://github.com/eclipse-tractusx/portal-iam

--- a/charts/sharedidp/README.md
+++ b/charts/sharedidp/README.md
@@ -1,6 +1,6 @@
 # Helm chart for Shared Keycloak Instance
 
-![Version: 4.2.0](https://img.shields.io/badge/Version-4.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.0.6](https://img.shields.io/badge/AppVersion-25.0.6-informational?style=flat-square)
+![Version: 4.2.1-rc.1](https://img.shields.io/badge/Version-4.2.1--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.0.6](https://img.shields.io/badge/AppVersion-25.0.6-informational?style=flat-square)
 
 This helm chart installs the Helm chart for Shared Keycloak Instance.
 
@@ -29,7 +29,7 @@ To use the helm chart as a dependency:
 dependencies:
   - name: sharedidp
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 4.2.0
+    version: 4.2.1-rc.1
 ```
 
 ## Requirements
@@ -42,6 +42,9 @@ dependencies:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| keycloak.image.registry | string | `"docker.io"` |  |
+| keycloak.image.repository | string | `"bitnamilegacy/keycloak"` |  |
+| keycloak.image.tag | string | `"25.0.6-debian-12-r0"` |  |
 | keycloak.auth.adminUser | string | `"admin"` |  |
 | keycloak.auth.adminPassword | string | `""` | sharedidp Keycloak administrator password. |
 | keycloak.auth.existingSecret | string | `""` | Secret containing the password for admin username 'admin'. |
@@ -78,7 +81,7 @@ dependencies:
 | keycloak.rbac.rules[0].verbs[0] | string | `"get"` |  |
 | keycloak.rbac.rules[0].verbs[1] | string | `"list"` |  |
 | keycloak.postgresql.enabled | bool | `true` | PostgreSQL chart configuration (recommended for demonstration purposes only); default configurations: host: "sharedidp-postgresql", port: 5432; Switch to enable or disable the PostgreSQL helm chart. |
-| keycloak.postgresql.image | object | `{"tag":"15-debian-11"}` | Setting to Postgres version 15 as that is the aligned version, https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-07/#aligning-dependency-versions). Keycloak helm-chart from Bitnami has moved on to version 16. |
+| keycloak.postgresql.image | object | `{"registry":"docker.io","repository":"bitnamilegacy/postgresql","tag":"15-debian-11"}` | Setting to Postgres version 15 as that is the aligned version, https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-07/#aligning-dependency-versions). Keycloak helm-chart from Bitnami has moved on to version 16. |
 | keycloak.postgresql.commonLabels."app.kubernetes.io/version" | string | `"15"` |  |
 | keycloak.postgresql.auth.username | string | `"kcshared"` | Non-root username. |
 | keycloak.postgresql.auth.password | string | `""` | Non-root user password. |

--- a/charts/sharedidp/values.yaml
+++ b/charts/sharedidp/values.yaml
@@ -18,6 +18,10 @@
 ###############################################################
 
 keycloak:
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/keycloak
+    tag: 25.0.6-debian-12-r0
   auth:
     adminUser: admin
     # -- sharedidp Keycloak administrator password.
@@ -103,6 +107,8 @@ keycloak:
     # https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-07/#aligning-dependency-versions).
     # Keycloak helm-chart from Bitnami has moved on to version 16.
     image:
+      registry: docker.io
+      repository: bitnamilegacy/postgresql
       tag: 15-debian-11
     commonLabels:
       app.kubernetes.io/version: "15"

--- a/environments/argocd-app-templates/centralidp/appsetup-int.yaml
+++ b/environments/argocd-app-templates/centralidp/appsetup-int.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/centralidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: v4.2.0
+    targetRevision: v4.2.1-rc.1
     plugin:
       env:
         - name: AVP_SECRET

--- a/environments/argocd-app-templates/centralidp/appsetup-stable.yaml
+++ b/environments/argocd-app-templates/centralidp/appsetup-stable.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/centralidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: v4.2.0
+    targetRevision: v4.2.1-rc.1
     plugin:
       env:
         - name: AVP_SECRET

--- a/environments/argocd-app-templates/sharedidp/appsetup-int.yaml
+++ b/environments/argocd-app-templates/sharedidp/appsetup-int.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/sharedidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: v4.2.0
+    targetRevision: v4.2.1-rc.1
     plugin:
       env:
         - name: AVP_SECRET

--- a/environments/argocd-app-templates/sharedidp/appsetup-stable.yaml
+++ b/environments/argocd-app-templates/sharedidp/appsetup-stable.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/sharedidp
     repoURL: 'https://github.com/eclipse-tractusx/portal-iam.git'
-    targetRevision: v4.2.0
+    targetRevision: v4.2.1-rc.1
     plugin:
       env:
         - name: AVP_SECRET


### PR DESCRIPTION
## Description

- change bitnami image path to legacy repository

## Why

- Bitnami now requires a paid subscription to use their images.

## Issue

Closes: #301 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
